### PR TITLE
feat: add version indicator to bottom of page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/build-push-action@v6
@@ -73,5 +84,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            COMMIT=${{ steps.version.outputs.commit }}
+            BUILD_DATE=${{ steps.version.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,15 @@ RUN bun run build
 
 FROM golang:1.25-alpine AS backend
 WORKDIR /app
+ARG VERSION=unknown
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ .
-RUN CGO_ENABLED=0 go build -o server ./cmd/server
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-X github.com/tobi/contracts/backend/internal/version.Version=${VERSION} -X github.com/tobi/contracts/backend/internal/version.Commit=${COMMIT} -X github.com/tobi/contracts/backend/internal/version.BuildDate=${BUILD_DATE}" \
+    -o server ./cmd/server
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -2,6 +2,16 @@ version: "3"
 
 vars:
   BINARY: server
+  VERSION:
+    sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+  COMMIT:
+    sh: git rev-parse --short HEAD 2>/dev/null || echo ""
+  BUILD_DATE:
+    sh: date -u +%Y-%m-%d
+  LDFLAGS: >-
+    -X github.com/tobi/contracts/backend/internal/version.Version={{.VERSION}}
+    -X github.com/tobi/contracts/backend/internal/version.Commit={{.COMMIT}}
+    -X github.com/tobi/contracts/backend/internal/version.BuildDate={{.BUILD_DATE}}
 
 tasks:
   dev:
@@ -15,7 +25,7 @@ tasks:
   build:
     desc: Build the binary
     cmds:
-      - go build -o {{.BINARY}} ./cmd/server
+      - go build -ldflags '{{.LDFLAGS}}' -o {{.BINARY}} ./cmd/server
 
   test:
     desc: Run tests

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -24,6 +24,7 @@ func main() {
 		handler = slog.NewTextHandler(os.Stdout, opts)
 	}
 	logger := slog.New(handler)
+	slog.SetDefault(logger)
 
 	db, err := store.NewBadgerStore(cfg.DBPath, logger)
 	if err != nil {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -78,7 +78,7 @@ func (s *Server) Run() error {
 	mux.Handle("GET /metrics", promhttp.Handler())
 	mux.HandleFunc("POST /api/v1/auth/register", h.Register)
 	mux.HandleFunc("POST /api/v1/auth/login", h.Login)
-	mux.HandleFunc("GET /api/version", version.Handler(s.logger))
+	mux.HandleFunc("GET /api/version", version.Handler)
 
 	// Mount protected API routes
 	mux.Handle("/api/v1/", protectedAPI)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tobi/contracts/backend/internal/middleware"
 	"github.com/tobi/contracts/backend/internal/reminder"
 	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/tobi/contracts/backend/internal/version"
 )
 
 type Server struct {
@@ -77,6 +78,7 @@ func (s *Server) Run() error {
 	mux.Handle("GET /metrics", promhttp.Handler())
 	mux.HandleFunc("POST /api/v1/auth/register", h.Register)
 	mux.HandleFunc("POST /api/v1/auth/login", h.Login)
+	mux.HandleFunc("GET /api/version", version.Handler)
 
 	// Mount protected API routes
 	mux.Handle("/api/v1/", protectedAPI)
@@ -101,7 +103,8 @@ func (s *Server) Run() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		s.logger.Info("server starting", "port", s.cfg.Port, "environment", s.cfg.Environment)
+		v := version.Get()
+		s.logger.Info("server starting", "port", s.cfg.Port, "environment", s.cfg.Environment, "version", v.Version, "commit", v.Commit)
 		errCh <- srv.ListenAndServe()
 	}()
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -78,7 +78,7 @@ func (s *Server) Run() error {
 	mux.Handle("GET /metrics", promhttp.Handler())
 	mux.HandleFunc("POST /api/v1/auth/register", h.Register)
 	mux.HandleFunc("POST /api/v1/auth/login", h.Login)
-	mux.HandleFunc("GET /api/version", version.Handler)
+	mux.HandleFunc("GET /api/version", version.Handler(s.logger))
 
 	// Mount protected API routes
 	mux.Handle("/api/v1/", protectedAPI)

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -26,9 +26,11 @@ func Get() Info {
 	}
 }
 
-func Handler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(Get()); err != nil {
-		slog.Error("encoding version response", "error", err)
+func Handler(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(Get()); err != nil {
+			logger.Error("encoding version response", "error", err)
+		}
 	}
 }

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -26,11 +26,9 @@ func Get() Info {
 	}
 }
 
-func Handler(logger *slog.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(Get()); err != nil {
-			logger.Error("encoding version response", "error", err)
-		}
+func Handler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Get()); err != nil {
+		slog.Error("encoding version response", "error", err)
 	}
 }

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -27,5 +28,7 @@ func Get() Info {
 
 func Handler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(Get())
+	if err := json.NewEncoder(w).Encode(Get()); err != nil {
+		slog.Error("encoding version response", "error", err)
+	}
 }

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+var (
+	Version   = "dev"
+	Commit    = ""
+	BuildDate = ""
+)
+
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	BuildDate string `json:"buildDate,omitempty"`
+}
+
+func Get() Info {
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildDate: BuildDate,
+	}
+}
+
+func Handler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(Get())
+}

--- a/backend/internal/version/version_test.go
+++ b/backend/internal/version/version_test.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +19,7 @@ func TestHandler(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
-	Handler(slog.Default())(rec, req)
+	Handler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -47,7 +46,7 @@ func TestHandler(t *testing.T) {
 func TestHandlerDefaults(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
-	Handler(slog.Default())(rec, req)
+	Handler(rec, req)
 
 	var info Info
 	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {

--- a/backend/internal/version/version_test.go
+++ b/backend/internal/version/version_test.go
@@ -1,0 +1,64 @@
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	Version = "v1.2.3"
+	Commit = "abc1234"
+	BuildDate = "2026-01-15"
+	t.Cleanup(func() {
+		Version = "dev"
+		Commit = ""
+		BuildDate = ""
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	Handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var info Info
+	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if info.Version != "v1.2.3" {
+		t.Errorf("version = %q, want %q", info.Version, "v1.2.3")
+	}
+	if info.Commit != "abc1234" {
+		t.Errorf("commit = %q, want %q", info.Commit, "abc1234")
+	}
+	if info.BuildDate != "2026-01-15" {
+		t.Errorf("buildDate = %q, want %q", info.BuildDate, "2026-01-15")
+	}
+}
+
+func TestHandlerDefaults(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	Handler(rec, req)
+
+	var info Info
+	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if info.Version != "dev" {
+		t.Errorf("version = %q, want %q", info.Version, "dev")
+	}
+	if info.Commit != "" {
+		t.Errorf("commit = %q, want empty", info.Commit)
+	}
+	if info.BuildDate != "" {
+		t.Errorf("buildDate = %q, want empty", info.BuildDate)
+	}
+}

--- a/backend/internal/version/version_test.go
+++ b/backend/internal/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,7 +20,7 @@ func TestHandler(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
-	Handler(rec, req)
+	Handler(slog.Default())(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -46,7 +47,7 @@ func TestHandler(t *testing.T) {
 func TestHandlerDefaults(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
-	Handler(rec, req)
+	Handler(slog.Default())(rec, req)
 
 	var info Info
 	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from "@/components/sidebar"
 import { useAuth } from "@/hooks/use-auth"
 import { Button } from "@/components/ui/button"
 import { LogOut } from "lucide-react"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 
 export const rootRoute = createRootRoute({
@@ -54,6 +54,35 @@ function RootLayout() {
           <Outlet />
         </main>
       </div>
+      <VersionIndicator />
+    </div>
+  )
+}
+
+function VersionIndicator() {
+  const [label, setLabel] = useState("")
+
+  useEffect(() => {
+    fetch("/api/version")
+      .then((r) => r.json())
+      .then((data: { version: string; commit?: string; buildDate?: string }) => {
+        const parts = [data.version]
+        if (data.buildDate) parts.push(data.buildDate)
+        if (data.commit) parts.push(data.commit)
+        setLabel(parts.join(" / "))
+      })
+      .catch(() => {})
+  }, [])
+
+  if (!label) return null
+
+  return (
+    <div className="py-1 text-center text-[11px] text-muted-foreground/60">
+      <a href="https://github.com/reusing-code/contracts" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground">
+        Contracts
+      </a>
+      {" "}
+      {label}
     </div>
   )
 }

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -63,7 +63,8 @@ function VersionIndicator() {
   const [label, setLabel] = useState("")
 
   useEffect(() => {
-    fetch("/api/version")
+    const controller = new AbortController()
+    fetch("/api/version", { signal: controller.signal })
       .then((r) => {
         if (!r.ok) throw new Error(r.statusText)
         return r.json()
@@ -75,6 +76,7 @@ function VersionIndicator() {
         setLabel(parts.join(" / "))
       })
       .catch(() => {})
+    return () => controller.abort()
   }, [])
 
   if (!label) return null

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -64,7 +64,10 @@ function VersionIndicator() {
 
   useEffect(() => {
     fetch("/api/version")
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(r.statusText)
+        return r.json()
+      })
       .then((data: { version: string; commit?: string; buildDate?: string }) => {
         const parts = [data.version]
         if (data.buildDate) parts.push(data.buildDate)


### PR DESCRIPTION
Add /api/version endpoint that returns version, commit hash, and build date. Version info is injected via ldflags at build time. CI passes git tag/branch, short SHA, and date as Docker build args. Dev builds show 'dev'. The frontend displays a subtle version label with a link to the GitHub repo at the bottom of the layout.