### PR TITLE
feat: add purchase tracking module with homepage and collapsible sidebar

### DIFF
--- a/backend/internal/handler/category.go
+++ b/backend/internal/handler/category.go
@@ -10,7 +10,8 @@ import (
 )
 
 func (h *Handler) ListCategories(w http.ResponseWriter, r *http.Request) {
-	categories, err := h.store.ListCategories(r.Context(), middleware.GetUserID(r.Context()))
+	module := r.PathValue("module")
+	categories, err := h.store.ListCategories(r.Context(), middleware.GetUserID(r.Context()), module)
 	if err != nil {
 		h.handleStoreError(w, err)
 		return
@@ -19,13 +20,14 @@ func (h *Handler) ListCategories(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetCategory(w http.ResponseWriter, r *http.Request) {
+	module := r.PathValue("module")
 	id, err := parseUUID(r.PathValue("id"))
 	if err != nil {
 		h.errorResponse(w, http.StatusBadRequest, "invalid id")
 		return
 	}
 
-	cat, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), id)
+	cat, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), module, id)
 	if err != nil {
 		h.handleStoreError(w, err)
 		return
@@ -34,6 +36,7 @@ func (h *Handler) GetCategory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) CreateCategory(w http.ResponseWriter, r *http.Request) {
+	module := r.PathValue("module")
 	var input model.CategoryInput
 	if err := h.readJSON(r, &input); err != nil {
 		h.errorResponse(w, http.StatusBadRequest, "invalid request body")
@@ -52,7 +55,7 @@ func (h *Handler) CreateCategory(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt: now,
 	}
 
-	if err := h.store.CreateCategory(r.Context(), middleware.GetUserID(r.Context()), cat); err != nil {
+	if err := h.store.CreateCategory(r.Context(), middleware.GetUserID(r.Context()), module, cat); err != nil {
 		h.handleStoreError(w, err)
 		return
 	}
@@ -60,13 +63,14 @@ func (h *Handler) CreateCategory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) UpdateCategory(w http.ResponseWriter, r *http.Request) {
+	module := r.PathValue("module")
 	id, err := parseUUID(r.PathValue("id"))
 	if err != nil {
 		h.errorResponse(w, http.StatusBadRequest, "invalid id")
 		return
 	}
 
-	existing, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), id)
+	existing, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), module, id)
 	if err != nil {
 		h.handleStoreError(w, err)
 		return
@@ -85,7 +89,7 @@ func (h *Handler) UpdateCategory(w http.ResponseWriter, r *http.Request) {
 	existing.Name = input.Name
 	existing.UpdatedAt = time.Now().UTC()
 
-	if err := h.store.UpdateCategory(r.Context(), middleware.GetUserID(r.Context()), existing); err != nil {
+	if err := h.store.UpdateCategory(r.Context(), middleware.GetUserID(r.Context()), module, existing); err != nil {
 		h.handleStoreError(w, err)
 		return
 	}
@@ -93,13 +97,14 @@ func (h *Handler) UpdateCategory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DeleteCategory(w http.ResponseWriter, r *http.Request) {
+	module := r.PathValue("module")
 	id, err := parseUUID(r.PathValue("id"))
 	if err != nil {
 		h.errorResponse(w, http.StatusBadRequest, "invalid id")
 		return
 	}
 
-	if err := h.store.DeleteCategory(r.Context(), middleware.GetUserID(r.Context()), id); err != nil {
+	if err := h.store.DeleteCategory(r.Context(), middleware.GetUserID(r.Context()), module, id); err != nil {
 		h.handleStoreError(w, err)
 		return
 	}

--- a/backend/internal/handler/contract.go
+++ b/backend/internal/handler/contract.go
@@ -40,8 +40,8 @@ func (h *Handler) CreateContractInCategory(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Verify category exists
-	if _, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), catID); err != nil {
+	// Verify category exists (contracts module)
+	if _, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), "contracts", catID); err != nil {
 		h.handleStoreError(w, err)
 		return
 	}

--- a/backend/internal/handler/import.go
+++ b/backend/internal/handler/import.go
@@ -63,7 +63,7 @@ func (h *Handler) ImportContracts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	categories, err := h.store.ListCategories(r.Context(), userID)
+	categories, err := h.store.ListCategories(r.Context(), userID, "contracts")
 	if err != nil {
 		h.handleStoreError(w, err)
 		return
@@ -109,7 +109,7 @@ func (h *Handler) ImportContracts(w http.ResponseWriter, r *http.Request) {
 				CreatedAt: now,
 				UpdatedAt: now,
 			}
-			if err := h.store.CreateCategory(r.Context(), userID, cat); err != nil {
+			if err := h.store.CreateCategory(r.Context(), userID, "contracts", cat); err != nil {
 				result.Errors = append(result.Errors, importError{Row: row, Error: fmt.Sprintf("failed to create category: %v", err)})
 				continue
 			}

--- a/backend/internal/handler/purchase.go
+++ b/backend/internal/handler/purchase.go
@@ -1,0 +1,156 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tobi/contracts/backend/internal/middleware"
+	"github.com/tobi/contracts/backend/internal/model"
+)
+
+func (h *Handler) ListPurchases(w http.ResponseWriter, r *http.Request) {
+	purchases, err := h.store.ListPurchases(r.Context(), middleware.GetUserID(r.Context()))
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, purchases)
+}
+
+func (h *Handler) ListPurchasesByCategory(w http.ResponseWriter, r *http.Request) {
+	catID, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid category id")
+		return
+	}
+
+	purchases, err := h.store.ListPurchasesByCategory(r.Context(), middleware.GetUserID(r.Context()), catID)
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, purchases)
+}
+
+func (h *Handler) CreatePurchaseInCategory(w http.ResponseWriter, r *http.Request) {
+	catID, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid category id")
+		return
+	}
+
+	if _, err := h.store.GetCategory(r.Context(), middleware.GetUserID(r.Context()), "purchases", catID); err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+
+	var input model.PurchaseInput
+	if err := h.readJSON(r, &input); err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := input.Validate(); err != nil {
+		h.errorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	p := model.Purchase{
+		ID:             uuid.New(),
+		CategoryID:     catID,
+		Type:           input.Type,
+		ItemName:       input.ItemName,
+		Brand:          input.Brand,
+		ArticleNumber:  input.ArticleNumber,
+		Dealer:         input.Dealer,
+		Price:          input.Price,
+		PurchaseDate:   input.PurchaseDate,
+		DescriptionURL: input.DescriptionURL,
+		InvoiceURL:     input.InvoiceURL,
+		HandbookURL:    input.HandbookURL,
+		Consumables:    input.Consumables,
+		Comments:       input.Comments,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := h.store.CreatePurchase(r.Context(), middleware.GetUserID(r.Context()), p); err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	h.writeJSON(w, http.StatusCreated, p)
+}
+
+func (h *Handler) GetPurchase(w http.ResponseWriter, r *http.Request) {
+	id, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	p, err := h.store.GetPurchase(r.Context(), middleware.GetUserID(r.Context()), id)
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, p)
+}
+
+func (h *Handler) UpdatePurchase(w http.ResponseWriter, r *http.Request) {
+	id, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	existing, err := h.store.GetPurchase(r.Context(), middleware.GetUserID(r.Context()), id)
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+
+	var input model.PurchaseInput
+	if err := h.readJSON(r, &input); err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := input.Validate(); err != nil {
+		h.errorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	existing.Type = input.Type
+	existing.ItemName = input.ItemName
+	existing.Brand = input.Brand
+	existing.ArticleNumber = input.ArticleNumber
+	existing.Dealer = input.Dealer
+	existing.Price = input.Price
+	existing.PurchaseDate = input.PurchaseDate
+	existing.DescriptionURL = input.DescriptionURL
+	existing.InvoiceURL = input.InvoiceURL
+	existing.HandbookURL = input.HandbookURL
+	existing.Consumables = input.Consumables
+	existing.Comments = input.Comments
+	existing.UpdatedAt = time.Now().UTC()
+
+	if err := h.store.UpdatePurchase(r.Context(), middleware.GetUserID(r.Context()), existing); err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, existing)
+}
+
+func (h *Handler) DeletePurchase(w http.ResponseWriter, r *http.Request) {
+	id, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	if err := h.store.DeletePurchase(r.Context(), middleware.GetUserID(r.Context()), id); err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/handler/purchase_summary.go
+++ b/backend/internal/handler/purchase_summary.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/tobi/contracts/backend/internal/middleware"
+)
+
+type purchaseCategorySummary struct {
+	ID            uuid.UUID `json:"id"`
+	Name          string    `json:"name"`
+	PurchaseCount int       `json:"purchaseCount"`
+	TotalSpent    float64   `json:"totalSpent"`
+}
+
+type purchaseSummaryResponse struct {
+	TotalPurchases int                       `json:"totalPurchases"`
+	TotalSpent     float64                   `json:"totalSpent"`
+	Categories     []purchaseCategorySummary `json:"categories"`
+}
+
+func (h *Handler) PurchaseSummary(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	cats, err := h.store.ListCategories(r.Context(), userID, "purchases")
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+
+	purchases, err := h.store.ListPurchases(r.Context(), userID)
+	if err != nil {
+		h.handleStoreError(w, err)
+		return
+	}
+
+	type agg struct {
+		count int
+		total float64
+	}
+	byCategory := make(map[uuid.UUID]*agg)
+	for _, cat := range cats {
+		byCategory[cat.ID] = &agg{}
+	}
+
+	var totalSpent float64
+	for _, p := range purchases {
+		a, ok := byCategory[p.CategoryID]
+		if !ok {
+			a = &agg{}
+			byCategory[p.CategoryID] = a
+		}
+		a.count++
+		if p.Price != nil {
+			a.total += *p.Price
+			totalSpent += *p.Price
+		}
+	}
+
+	catSummaries := make([]purchaseCategorySummary, 0, len(cats))
+	for _, cat := range cats {
+		a := byCategory[cat.ID]
+		catSummaries = append(catSummaries, purchaseCategorySummary{
+			ID:            cat.ID,
+			Name:          cat.Name,
+			PurchaseCount: a.count,
+			TotalSpent:    a.total,
+		})
+	}
+
+	h.writeJSON(w, http.StatusOK, purchaseSummaryResponse{
+		TotalPurchases: len(purchases),
+		TotalSpent:     totalSpent,
+		Categories:     catSummaries,
+	})
+}

--- a/backend/internal/handler/summary.go
+++ b/backend/internal/handler/summary.go
@@ -23,7 +23,7 @@ type summaryResponse struct {
 }
 
 func (h *Handler) Summary(w http.ResponseWriter, r *http.Request) {
-	cats, err := h.store.ListCategories(r.Context(), middleware.GetUserID(r.Context()))
+	cats, err := h.store.ListCategories(r.Context(), middleware.GetUserID(r.Context()), "contracts")
 	if err != nil {
 		h.handleStoreError(w, err)
 		return

--- a/backend/internal/model/purchase.go
+++ b/backend/internal/model/purchase.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Purchase struct {
+	ID             uuid.UUID `json:"id"`
+	CategoryID     uuid.UUID `json:"categoryId"`
+	Type           string    `json:"type,omitempty"`
+	ItemName       string    `json:"itemName"`
+	Brand          string    `json:"brand,omitempty"`
+	ArticleNumber  string    `json:"articleNumber,omitempty"`
+	Dealer         string    `json:"dealer,omitempty"`
+	Price          *float64  `json:"price,omitempty"`
+	PurchaseDate   string    `json:"purchaseDate,omitempty"`
+	DescriptionURL string    `json:"descriptionUrl,omitempty"`
+	InvoiceURL     string    `json:"invoiceUrl,omitempty"`
+	HandbookURL    string    `json:"handbookUrl,omitempty"`
+	Consumables    string    `json:"consumables,omitempty"`
+	Comments       string    `json:"comments,omitempty"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
+type PurchaseInput struct {
+	Type           string   `json:"type,omitempty"`
+	ItemName       string   `json:"itemName"`
+	Brand          string   `json:"brand,omitempty"`
+	ArticleNumber  string   `json:"articleNumber,omitempty"`
+	Dealer         string   `json:"dealer,omitempty"`
+	Price          *float64 `json:"price,omitempty"`
+	PurchaseDate   string   `json:"purchaseDate,omitempty"`
+	DescriptionURL string   `json:"descriptionUrl,omitempty"`
+	InvoiceURL     string   `json:"invoiceUrl,omitempty"`
+	HandbookURL    string   `json:"handbookUrl,omitempty"`
+	Consumables    string   `json:"consumables,omitempty"`
+	Comments       string   `json:"comments,omitempty"`
+}
+
+func (p *PurchaseInput) Validate() error {
+	if p.ItemName == "" {
+		return errors.New("itemName is required")
+	}
+	return nil
+}

--- a/backend/internal/reminder/scheduler_test.go
+++ b/backend/internal/reminder/scheduler_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 type mockStore struct {
-	users    []model.User
-	settings map[string]model.UserSettings
+	users     []model.User
+	settings  map[string]model.UserSettings
 	contracts map[string][]model.Contract
 }
 
@@ -40,15 +40,21 @@ func (m *mockStore) UpdateSettings(_ context.Context, userID string, s model.Use
 	m.settings[userID] = s
 	return nil
 }
-func (m *mockStore) ListCategories(_ context.Context, _ string) ([]model.Category, error) {
+func (m *mockStore) ListCategories(_ context.Context, _ string, _ string) ([]model.Category, error) {
 	return nil, nil
 }
-func (m *mockStore) GetCategory(_ context.Context, _ string, _ uuid.UUID) (model.Category, error) {
+func (m *mockStore) GetCategory(_ context.Context, _ string, _ string, _ uuid.UUID) (model.Category, error) {
 	return model.Category{}, nil
 }
-func (m *mockStore) CreateCategory(_ context.Context, _ string, _ model.Category) error { return nil }
-func (m *mockStore) UpdateCategory(_ context.Context, _ string, _ model.Category) error { return nil }
-func (m *mockStore) DeleteCategory(_ context.Context, _ string, _ uuid.UUID) error      { return nil }
+func (m *mockStore) CreateCategory(_ context.Context, _ string, _ string, _ model.Category) error {
+	return nil
+}
+func (m *mockStore) UpdateCategory(_ context.Context, _ string, _ string, _ model.Category) error {
+	return nil
+}
+func (m *mockStore) DeleteCategory(_ context.Context, _ string, _ string, _ uuid.UUID) error {
+	return nil
+}
 func (m *mockStore) ListContracts(_ context.Context, userID string) ([]model.Contract, error) {
 	return m.contracts[userID], nil
 }
@@ -61,6 +67,18 @@ func (m *mockStore) GetContract(_ context.Context, _ string, _ uuid.UUID) (model
 func (m *mockStore) CreateContract(_ context.Context, _ string, _ model.Contract) error { return nil }
 func (m *mockStore) UpdateContract(_ context.Context, _ string, _ model.Contract) error { return nil }
 func (m *mockStore) DeleteContract(_ context.Context, _ string, _ uuid.UUID) error      { return nil }
+func (m *mockStore) ListPurchases(_ context.Context, _ string) ([]model.Purchase, error) {
+	return nil, nil
+}
+func (m *mockStore) ListPurchasesByCategory(_ context.Context, _ string, _ uuid.UUID) ([]model.Purchase, error) {
+	return nil, nil
+}
+func (m *mockStore) GetPurchase(_ context.Context, _ string, _ uuid.UUID) (model.Purchase, error) {
+	return model.Purchase{}, nil
+}
+func (m *mockStore) CreatePurchase(_ context.Context, _ string, _ model.Purchase) error { return nil }
+func (m *mockStore) UpdatePurchase(_ context.Context, _ string, _ model.Purchase) error { return nil }
+func (m *mockStore) DeletePurchase(_ context.Context, _ string, _ uuid.UUID) error      { return nil }
 func (m *mockStore) Close() error                                                       { return nil }
 
 func newTestUser() model.User {

--- a/backend/internal/server/integration_test.go
+++ b/backend/internal/server/integration_test.go
@@ -31,11 +31,14 @@ func setupServer(t *testing.T) *httptest.Server {
 	h := handler.New(s, logger, testJWTSecret, nil)
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("GET /api/v1/categories", h.ListCategories)
-	mux.HandleFunc("POST /api/v1/categories", h.CreateCategory)
-	mux.HandleFunc("GET /api/v1/categories/{id}", h.GetCategory)
-	mux.HandleFunc("PUT /api/v1/categories/{id}", h.UpdateCategory)
-	mux.HandleFunc("DELETE /api/v1/categories/{id}", h.DeleteCategory)
+	// Module-scoped category routes
+	mux.HandleFunc("GET /api/v1/modules/{module}/categories", h.ListCategories)
+	mux.HandleFunc("POST /api/v1/modules/{module}/categories", h.CreateCategory)
+	mux.HandleFunc("GET /api/v1/modules/{module}/categories/{id}", h.GetCategory)
+	mux.HandleFunc("PUT /api/v1/modules/{module}/categories/{id}", h.UpdateCategory)
+	mux.HandleFunc("DELETE /api/v1/modules/{module}/categories/{id}", h.DeleteCategory)
+
+	// Contract routes
 	mux.HandleFunc("GET /api/v1/categories/{id}/contracts", h.ListContractsByCategory)
 	mux.HandleFunc("POST /api/v1/categories/{id}/contracts", h.CreateContractInCategory)
 	mux.HandleFunc("GET /api/v1/contracts/upcoming-renewals", h.UpcomingRenewals)
@@ -44,6 +47,15 @@ func setupServer(t *testing.T) *httptest.Server {
 	mux.HandleFunc("PUT /api/v1/contracts/{id}", h.UpdateContract)
 	mux.HandleFunc("DELETE /api/v1/contracts/{id}", h.DeleteContract)
 	mux.HandleFunc("GET /api/v1/summary", h.Summary)
+
+	// Purchase routes
+	mux.HandleFunc("GET /api/v1/categories/{id}/purchases", h.ListPurchasesByCategory)
+	mux.HandleFunc("POST /api/v1/categories/{id}/purchases", h.CreatePurchaseInCategory)
+	mux.HandleFunc("GET /api/v1/purchases/summary", h.PurchaseSummary)
+	mux.HandleFunc("GET /api/v1/purchases", h.ListPurchases)
+	mux.HandleFunc("GET /api/v1/purchases/{id}", h.GetPurchase)
+	mux.HandleFunc("PUT /api/v1/purchases/{id}", h.UpdatePurchase)
+	mux.HandleFunc("DELETE /api/v1/purchases/{id}", h.DeletePurchase)
 
 	// Inject test user into context (integration tests skip auth middleware)
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +112,7 @@ func TestIntegration_FullCRUDFlow(t *testing.T) {
 	base := srv.URL
 
 	// List categories — empty
-	resp := doJSON(t, "GET", base+"/api/v1/categories", nil)
+	resp := doJSON(t, "GET", base+"/api/v1/modules/contracts/categories", nil)
 	expectStatus(t, resp, 200)
 	cats := decode[[]model.Category](t, resp)
 	if len(cats) != 0 {
@@ -108,7 +120,7 @@ func TestIntegration_FullCRUDFlow(t *testing.T) {
 	}
 
 	// Create category
-	resp = doJSON(t, "POST", base+"/api/v1/categories", map[string]string{"name": "Telecom"})
+	resp = doJSON(t, "POST", base+"/api/v1/modules/contracts/categories", map[string]string{"name": "Telecom"})
 	expectStatus(t, resp, 201)
 	cat := decode[model.Category](t, resp)
 	if cat.Name != "Telecom" {
@@ -116,7 +128,7 @@ func TestIntegration_FullCRUDFlow(t *testing.T) {
 	}
 
 	// Get category
-	resp = doJSON(t, "GET", base+"/api/v1/categories/"+cat.ID.String(), nil)
+	resp = doJSON(t, "GET", base+"/api/v1/modules/contracts/categories/"+cat.ID.String(), nil)
 	expectStatus(t, resp, 200)
 	got := decode[model.Category](t, resp)
 	if got.ID != cat.ID {
@@ -124,7 +136,7 @@ func TestIntegration_FullCRUDFlow(t *testing.T) {
 	}
 
 	// Update category
-	resp = doJSON(t, "PUT", base+"/api/v1/categories/"+cat.ID.String(), map[string]string{"name": "Telecommunications"})
+	resp = doJSON(t, "PUT", base+"/api/v1/modules/contracts/categories/"+cat.ID.String(), map[string]string{"name": "Telecommunications"})
 	expectStatus(t, resp, 200)
 	updated := decode[model.Category](t, resp)
 	if updated.Name != "Telecommunications" {
@@ -194,12 +206,12 @@ func TestIntegration_FullCRUDFlow(t *testing.T) {
 	resp.Body.Close()
 
 	// Delete category
-	resp = doJSON(t, "DELETE", base+"/api/v1/categories/"+cat.ID.String(), nil)
+	resp = doJSON(t, "DELETE", base+"/api/v1/modules/contracts/categories/"+cat.ID.String(), nil)
 	expectStatus(t, resp, 204)
 	resp.Body.Close()
 
 	// Verify category is gone
-	resp = doJSON(t, "GET", base+"/api/v1/categories/"+cat.ID.String(), nil)
+	resp = doJSON(t, "GET", base+"/api/v1/modules/contracts/categories/"+cat.ID.String(), nil)
 	expectStatus(t, resp, 404)
 	resp.Body.Close()
 }
@@ -210,7 +222,7 @@ func TestIntegration_CascadeDelete(t *testing.T) {
 	base := srv.URL
 
 	// Create category with two contracts
-	resp := doJSON(t, "POST", base+"/api/v1/categories", map[string]string{"name": "Insurance"})
+	resp := doJSON(t, "POST", base+"/api/v1/modules/contracts/categories", map[string]string{"name": "Insurance"})
 	expectStatus(t, resp, 201)
 	cat := decode[model.Category](t, resp)
 
@@ -225,7 +237,7 @@ func TestIntegration_CascadeDelete(t *testing.T) {
 	con2 := decode[model.Contract](t, resp)
 
 	// Delete category — contracts should cascade
-	resp = doJSON(t, "DELETE", base+"/api/v1/categories/"+cat.ID.String(), nil)
+	resp = doJSON(t, "DELETE", base+"/api/v1/modules/contracts/categories/"+cat.ID.String(), nil)
 	expectStatus(t, resp, 204)
 	resp.Body.Close()
 
@@ -250,7 +262,7 @@ func TestIntegration_Summary(t *testing.T) {
 	}
 
 	// Create category + contract with price
-	resp = doJSON(t, "POST", base+"/api/v1/categories", map[string]string{"name": "Insurance"})
+	resp = doJSON(t, "POST", base+"/api/v1/modules/contracts/categories", map[string]string{"name": "Insurance"})
 	expectStatus(t, resp, 201)
 	cat := decode[model.Category](t, resp)
 
@@ -295,7 +307,7 @@ func TestIntegration_UpcomingRenewals(t *testing.T) {
 	}
 
 	// Create category + contract (no endDate, so it gets a cancellation date)
-	resp = doJSON(t, "POST", base+"/api/v1/categories", map[string]string{"name": "Telecom"})
+	resp = doJSON(t, "POST", base+"/api/v1/modules/contracts/categories", map[string]string{"name": "Telecom"})
 	expectStatus(t, resp, 201)
 	cat := decode[model.Category](t, resp)
 
@@ -332,7 +344,7 @@ func TestIntegration_ContractResponse_HasComputedFields(t *testing.T) {
 	base := srv.URL
 
 	// Create category + contract
-	resp := doJSON(t, "POST", base+"/api/v1/categories", map[string]string{"name": "Test"})
+	resp := doJSON(t, "POST", base+"/api/v1/modules/contracts/categories", map[string]string{"name": "Test"})
 	expectStatus(t, resp, 201)
 	cat := decode[model.Category](t, resp)
 

--- a/backend/internal/server/integration_test.go
+++ b/backend/internal/server/integration_test.go
@@ -376,3 +376,108 @@ func TestIntegration_ContractResponse_HasComputedFields(t *testing.T) {
 		t.Error("expected cancellationDate in get response")
 	}
 }
+
+func TestIntegration_PurchaseCRUDFlow(t *testing.T) {
+	srv := setupServer(t)
+	defer srv.Close()
+	base := srv.URL
+
+	// List purchase categories — empty
+	resp := doJSON(t, "GET", base+"/api/v1/modules/purchases/categories", nil)
+	expectStatus(t, resp, 200)
+	cats := decode[[]model.Category](t, resp)
+	if len(cats) != 0 {
+		t.Fatalf("expected 0 categories, got %d", len(cats))
+	}
+
+	// Create purchase category
+	resp = doJSON(t, "POST", base+"/api/v1/modules/purchases/categories", map[string]string{"name": "PC Hardware"})
+	expectStatus(t, resp, 201)
+	cat := decode[model.Category](t, resp)
+	if cat.Name != "PC Hardware" {
+		t.Fatalf("Name = %q, want %q", cat.Name, "PC Hardware")
+	}
+
+	// Create purchase in category
+	price := 299.99
+	purBody := map[string]any{
+		"itemName":     "Graphics Card",
+		"brand":        "NVIDIA",
+		"dealer":       "Amazon",
+		"price":        price,
+		"purchaseDate": "2025-06-15",
+	}
+	resp = doJSON(t, "POST", base+"/api/v1/categories/"+cat.ID.String()+"/purchases", purBody)
+	expectStatus(t, resp, 201)
+	pur := decode[model.Purchase](t, resp)
+	if pur.ItemName != "Graphics Card" {
+		t.Fatalf("ItemName = %q, want %q", pur.ItemName, "Graphics Card")
+	}
+	if pur.CategoryID != cat.ID {
+		t.Fatalf("CategoryID = %s, want %s", pur.CategoryID, cat.ID)
+	}
+
+	// Get purchase
+	resp = doJSON(t, "GET", base+"/api/v1/purchases/"+pur.ID.String(), nil)
+	expectStatus(t, resp, 200)
+	gotPur := decode[model.Purchase](t, resp)
+	if gotPur.Brand != "NVIDIA" {
+		t.Fatalf("Brand = %q, want %q", gotPur.Brand, "NVIDIA")
+	}
+
+	// List purchases for category
+	resp = doJSON(t, "GET", base+"/api/v1/categories/"+cat.ID.String()+"/purchases", nil)
+	expectStatus(t, resp, 200)
+	purs := decode[[]model.Purchase](t, resp)
+	if len(purs) != 1 {
+		t.Fatalf("expected 1 purchase, got %d", len(purs))
+	}
+
+	// List all purchases
+	resp = doJSON(t, "GET", base+"/api/v1/purchases", nil)
+	expectStatus(t, resp, 200)
+	allPurs := decode[[]model.Purchase](t, resp)
+	if len(allPurs) != 1 {
+		t.Fatalf("expected 1 purchase, got %d", len(allPurs))
+	}
+
+	// Update purchase
+	purBody["itemName"] = "Updated Graphics Card"
+	resp = doJSON(t, "PUT", base+"/api/v1/purchases/"+pur.ID.String(), purBody)
+	expectStatus(t, resp, 200)
+	updatedPur := decode[model.Purchase](t, resp)
+	if updatedPur.ItemName != "Updated Graphics Card" {
+		t.Fatalf("ItemName = %q, want %q", updatedPur.ItemName, "Updated Graphics Card")
+	}
+
+	// Purchase summary
+	resp = doJSON(t, "GET", base+"/api/v1/purchases/summary", nil)
+	expectStatus(t, resp, 200)
+	summary := decode[map[string]any](t, resp)
+	if int(summary["totalPurchases"].(float64)) != 1 {
+		t.Fatalf("expected 1 totalPurchases, got %v", summary["totalPurchases"])
+	}
+	if summary["totalSpent"].(float64) != price {
+		t.Fatalf("expected totalSpent %v, got %v", price, summary["totalSpent"])
+	}
+
+	// Delete purchase
+	resp = doJSON(t, "DELETE", base+"/api/v1/purchases/"+pur.ID.String(), nil)
+	expectStatus(t, resp, 204)
+	resp.Body.Close()
+
+	// Verify purchase is gone
+	resp = doJSON(t, "GET", base+"/api/v1/purchases/"+pur.ID.String(), nil)
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+
+	// Delete category
+	resp = doJSON(t, "DELETE", base+"/api/v1/modules/purchases/categories/"+cat.ID.String(), nil)
+	expectStatus(t, resp, 204)
+	resp.Body.Close()
+
+	// Verify category is gone
+	resp = doJSON(t, "GET", base+"/api/v1/modules/purchases/categories/"+cat.ID.String(), nil)
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -49,11 +49,15 @@ func (s *Server) Run() error {
 
 	// Protected API routes (require auth)
 	apiMux := http.NewServeMux()
-	apiMux.HandleFunc("GET /api/v1/categories", h.ListCategories)
-	apiMux.HandleFunc("POST /api/v1/categories", h.CreateCategory)
-	apiMux.HandleFunc("GET /api/v1/categories/{id}", h.GetCategory)
-	apiMux.HandleFunc("PUT /api/v1/categories/{id}", h.UpdateCategory)
-	apiMux.HandleFunc("DELETE /api/v1/categories/{id}", h.DeleteCategory)
+
+	// Module-scoped category routes
+	apiMux.HandleFunc("GET /api/v1/modules/{module}/categories", h.ListCategories)
+	apiMux.HandleFunc("POST /api/v1/modules/{module}/categories", h.CreateCategory)
+	apiMux.HandleFunc("GET /api/v1/modules/{module}/categories/{id}", h.GetCategory)
+	apiMux.HandleFunc("PUT /api/v1/modules/{module}/categories/{id}", h.UpdateCategory)
+	apiMux.HandleFunc("DELETE /api/v1/modules/{module}/categories/{id}", h.DeleteCategory)
+
+	// Contract routes
 	apiMux.HandleFunc("GET /api/v1/categories/{id}/contracts", h.ListContractsByCategory)
 	apiMux.HandleFunc("POST /api/v1/categories/{id}/contracts", h.CreateContractInCategory)
 	apiMux.HandleFunc("POST /api/v1/contracts/import", h.ImportContracts)
@@ -63,6 +67,17 @@ func (s *Server) Run() error {
 	apiMux.HandleFunc("PUT /api/v1/contracts/{id}", h.UpdateContract)
 	apiMux.HandleFunc("DELETE /api/v1/contracts/{id}", h.DeleteContract)
 	apiMux.HandleFunc("GET /api/v1/summary", h.Summary)
+
+	// Purchase routes
+	apiMux.HandleFunc("GET /api/v1/categories/{id}/purchases", h.ListPurchasesByCategory)
+	apiMux.HandleFunc("POST /api/v1/categories/{id}/purchases", h.CreatePurchaseInCategory)
+	apiMux.HandleFunc("GET /api/v1/purchases/summary", h.PurchaseSummary)
+	apiMux.HandleFunc("GET /api/v1/purchases", h.ListPurchases)
+	apiMux.HandleFunc("GET /api/v1/purchases/{id}", h.GetPurchase)
+	apiMux.HandleFunc("PUT /api/v1/purchases/{id}", h.UpdatePurchase)
+	apiMux.HandleFunc("DELETE /api/v1/purchases/{id}", h.DeletePurchase)
+
+	// Settings routes
 	apiMux.HandleFunc("GET /api/v1/settings", h.GetSettings)
 	apiMux.HandleFunc("PUT /api/v1/settings", h.UpdateSettings)
 	apiMux.HandleFunc("PUT /api/v1/settings/password", h.ChangePassword)

--- a/backend/internal/store/migration/registry.go
+++ b/backend/internal/store/migration/registry.go
@@ -2,4 +2,5 @@ package migration
 
 var All = []Migration{
 	V1RenamePriceField,
+	V2ModuleCategories,
 }

--- a/backend/internal/store/migration/v2_module_categories.go
+++ b/backend/internal/store/migration/v2_module_categories.go
@@ -1,0 +1,87 @@
+package migration
+
+import (
+	"strings"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+var V2ModuleCategories = Migration{
+	Version:     2,
+	Description: "move category keys from u/{userId}/cat/ to u/{userId}/mod/contracts/cat/",
+	Run:         v2ModuleCategories,
+}
+
+func v2ModuleCategories(db *badger.DB) error {
+	type kv struct {
+		oldKey []byte
+		newKey []byte
+		val    []byte
+	}
+	var moves []kv
+
+	err := db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		prefix := []byte("u/")
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			key := string(item.Key())
+
+			// Match u/{userId}/cat/{catId} but NOT u/{userId}/mod/*/cat/*
+			userEnd := strings.Index(key[2:], "/")
+			if userEnd < 0 {
+				continue
+			}
+			userEnd += 2
+			rest := key[userEnd:]
+			if !strings.HasPrefix(rest, "/cat/") {
+				continue
+			}
+			catID := rest[5:]
+			if catID == "" {
+				continue
+			}
+
+			userID := key[2:userEnd]
+			newKey := "u/" + userID + "/mod/contracts/cat/" + catID
+
+			err := item.Value(func(val []byte) error {
+				keyCopy := make([]byte, len(item.Key()))
+				copy(keyCopy, item.Key())
+				valCopy := make([]byte, len(val))
+				copy(valCopy, val)
+				moves = append(moves, kv{
+					oldKey: keyCopy,
+					newKey: []byte(newKey),
+					val:    valCopy,
+				})
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(moves) == 0 {
+		return nil
+	}
+
+	return db.Update(func(txn *badger.Txn) error {
+		for _, m := range moves {
+			if err := txn.Set(m.newKey, m.val); err != nil {
+				return err
+			}
+			if err := txn.Delete(m.oldKey); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -17,11 +17,11 @@ type Store interface {
 	GetSettings(ctx context.Context, userID string) (model.UserSettings, error)
 	UpdateSettings(ctx context.Context, userID string, s model.UserSettings) error
 
-	ListCategories(ctx context.Context, userID string) ([]model.Category, error)
-	GetCategory(ctx context.Context, userID string, id uuid.UUID) (model.Category, error)
-	CreateCategory(ctx context.Context, userID string, c model.Category) error
-	UpdateCategory(ctx context.Context, userID string, c model.Category) error
-	DeleteCategory(ctx context.Context, userID string, id uuid.UUID) error
+	ListCategories(ctx context.Context, userID string, module string) ([]model.Category, error)
+	GetCategory(ctx context.Context, userID string, module string, id uuid.UUID) (model.Category, error)
+	CreateCategory(ctx context.Context, userID string, module string, c model.Category) error
+	UpdateCategory(ctx context.Context, userID string, module string, c model.Category) error
+	DeleteCategory(ctx context.Context, userID string, module string, id uuid.UUID) error
 
 	ListContracts(ctx context.Context, userID string) ([]model.Contract, error)
 	ListContractsByCategory(ctx context.Context, userID string, categoryID uuid.UUID) ([]model.Contract, error)
@@ -29,6 +29,13 @@ type Store interface {
 	CreateContract(ctx context.Context, userID string, c model.Contract) error
 	UpdateContract(ctx context.Context, userID string, c model.Contract) error
 	DeleteContract(ctx context.Context, userID string, id uuid.UUID) error
+
+	ListPurchases(ctx context.Context, userID string) ([]model.Purchase, error)
+	ListPurchasesByCategory(ctx context.Context, userID string, categoryID uuid.UUID) ([]model.Purchase, error)
+	GetPurchase(ctx context.Context, userID string, id uuid.UUID) (model.Purchase, error)
+	CreatePurchase(ctx context.Context, userID string, p model.Purchase) error
+	UpdatePurchase(ctx context.Context, userID string, p model.Purchase) error
+	DeletePurchase(ctx context.Context, userID string, id uuid.UUID) error
 
 	Close() error
 }

--- a/frontend/src/components/category-card.tsx
+++ b/frontend/src/components/category-card.tsx
@@ -13,21 +13,36 @@ import {
 
 interface CategoryCardProps {
   category: Category
-  contractCount: number
-  monthlyTotal: number
-  yearlyTotal: number
+  module: "contracts" | "purchases"
+  totalAmount: number
+  secondaryAmount?: number
+  itemLabel: string
+  totalLabel: string
+  secondaryLabel?: string
   onEdit: () => void
   onDelete: () => void
 }
 
-export function CategoryCard({ category, contractCount, monthlyTotal, yearlyTotal, onEdit, onDelete }: CategoryCardProps) {
+export function CategoryCard({
+  category,
+  module,
+  totalAmount,
+  secondaryAmount,
+  itemLabel,
+  totalLabel,
+  secondaryLabel,
+  onEdit,
+  onDelete,
+}: CategoryCardProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
+
+  const basePath = module === "contracts" ? "/contracts" : "/purchases"
 
   return (
     <Card
       className="cursor-pointer transition-colors hover:bg-accent/50"
-      onClick={() => navigate({ to: "/categories/$categoryId", params: { categoryId: category.id } })}
+      onClick={() => navigate({ to: `${basePath}/categories/$categoryId`, params: { categoryId: category.id } })}
     >
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-lg font-semibold">
@@ -49,20 +64,16 @@ export function CategoryCard({ category, contractCount, monthlyTotal, yearlyTota
       </CardHeader>
       <CardContent>
         <p className="text-sm text-muted-foreground">
-          {t("dashboard.contractCount", { count: contractCount })}
+          {itemLabel}
         </p>
-        {monthlyTotal > 0 && (
+        {totalAmount > 0 && (
           <p className="text-sm font-medium mt-1">
-            {t("dashboard.monthlyTotal", {
-              amount: `${monthlyTotal.toFixed(2)} ${t("common.currency")}`,
-            })}
+            {totalLabel}
           </p>
         )}
-        {yearlyTotal > 0 && (
+        {secondaryAmount !== undefined && secondaryAmount > 0 && secondaryLabel && (
           <p className="text-sm font-medium mt-1">
-            {t("dashboard.yearlyTotal", {
-              amount: `${yearlyTotal.toFixed(2)} ${t("common.currency")}`,
-            })}
+            {secondaryLabel}
           </p>
         )}
       </CardContent>

--- a/frontend/src/components/contract-dialog.tsx
+++ b/frontend/src/components/contract-dialog.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { contractFormSchema, type ContractFormData, type Contract } from "@/types/contract"
 import { contractFields } from "@/config/contract-fields"
-import { ContractFormField } from "@/components/contract-form-field"
+import { FormFieldRenderer } from "@/components/contract-form-field"
 import {
   Dialog,
   DialogContent,
@@ -80,7 +80,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSubmit }: Contr
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
             {contractFields.map((field) => (
-              <ContractFormField key={field.key} config={field} control={form.control} />
+              <FormFieldRenderer<ContractFormData> key={field.key} config={field} control={form.control} />
             ))}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/frontend/src/components/contract-form-field.tsx
+++ b/frontend/src/components/contract-form-field.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next"
 import type { FieldConfig } from "@/config/contract-fields"
-import type { ContractFormData } from "@/types/contract"
-import type { Control } from "react-hook-form"
+import type { Control, FieldValues, Path } from "react-hook-form"
 import {
   FormControl,
   FormField,
@@ -19,18 +18,18 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
-interface ContractFormFieldProps {
+interface FormFieldRendererProps<T extends FieldValues> {
   config: FieldConfig
-  control: Control<ContractFormData>
+  control: Control<T>
 }
 
-export function ContractFormField({ config, control }: ContractFormFieldProps) {
+export function FormFieldRenderer<T extends FieldValues>({ config, control }: FormFieldRendererProps<T>) {
   const { t } = useTranslation()
 
   return (
     <FormField
       control={control}
-      name={config.key as keyof ContractFormData}
+      name={config.key as Path<T>}
       render={({ field }) => (
         <FormItem>
           <FormLabel>
@@ -79,3 +78,6 @@ export function ContractFormField({ config, control }: ContractFormFieldProps) {
     />
   )
 }
+
+// Re-export for backward compatibility
+export const ContractFormField = FormFieldRenderer

--- a/frontend/src/components/contracts-table.tsx
+++ b/frontend/src/components/contracts-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { format } from "date-fns"
 import { ChevronRight, ExternalLink, FileText, MoreVertical } from "lucide-react"
@@ -20,10 +20,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import {
-  Collapsible,
-  CollapsibleContent,
-} from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 
 const tableColumns = contractFields
@@ -65,8 +61,7 @@ function ContractDetailRow({ contract, colSpan }: ContractDetailRowProps) {
   return (
     <TableRow className="bg-muted/30 hover:bg-muted/30">
       <TableCell colSpan={colSpan} className="p-0">
-        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapse data-[state=open]:animate-expand">
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
             {detailFields.map((field) => {
               const value = formatCellValue(contract, field.key, currency, t)
               if (value === "-" && field.type === "textarea") return null
@@ -91,7 +86,6 @@ function ContractDetailRow({ contract, colSpan }: ContractDetailRowProps) {
               )
             })}
           </div>
-        </CollapsibleContent>
       </TableCell>
     </TableRow>
   )
@@ -134,8 +128,7 @@ export function ContractsTable({ contracts, onEdit, onDelete, getRowClassName }:
               const rowClass = getRowClassName?.(contract)
               const isExpanded = expandedId === contract.id
               return (
-                <Collapsible key={contract.id} open={isExpanded} asChild>
-                  <>
+                <Fragment key={contract.id}>
                     <TableRow
                       className={cn(
                         contract.expired ? "opacity-50" : undefined,
@@ -207,9 +200,8 @@ export function ContractsTable({ contracts, onEdit, onDelete, getRowClassName }:
                         </DropdownMenu>
                       </TableCell>
                     </TableRow>
-                    <ContractDetailRow contract={contract} colSpan={totalColumns} />
-                  </>
-                </Collapsible>
+                    {isExpanded && <ContractDetailRow contract={contract} colSpan={totalColumns} />}
+                </Fragment>
               )
             })
           )}

--- a/frontend/src/components/purchase-dialog.tsx
+++ b/frontend/src/components/purchase-dialog.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+import { useForm } from "react-hook-form"
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
+import { purchaseFormSchema, type PurchaseFormData, type Purchase } from "@/types/purchase"
+import { purchaseFields } from "@/config/purchase-fields"
+import { FormFieldRenderer } from "@/components/contract-form-field"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+
+interface PurchaseDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  purchase?: Purchase | null
+  onSubmit: (data: PurchaseFormData) => void
+}
+
+const defaultValues: PurchaseFormData = {
+  itemName: "",
+  purchaseDate: new Date().toISOString().slice(0, 10),
+}
+
+export function PurchaseDialog({ open, onOpenChange, purchase, onSubmit }: PurchaseDialogProps) {
+  const { t } = useTranslation()
+  const form = useForm<PurchaseFormData>({
+    resolver: standardSchemaResolver(purchaseFormSchema),
+    defaultValues,
+  })
+
+  useEffect(() => {
+    if (open) {
+      if (purchase) {
+        form.reset({
+          type: purchase.type,
+          itemName: purchase.itemName,
+          brand: purchase.brand,
+          articleNumber: purchase.articleNumber,
+          dealer: purchase.dealer,
+          price: purchase.price,
+          purchaseDate: purchase.purchaseDate,
+          descriptionUrl: purchase.descriptionUrl,
+          invoiceUrl: purchase.invoiceUrl,
+          handbookUrl: purchase.handbookUrl,
+          consumables: purchase.consumables,
+          comments: purchase.comments,
+        })
+      } else {
+        form.reset(defaultValues)
+      }
+    }
+  }, [open, purchase, form])
+
+  function handleSubmit(data: PurchaseFormData) {
+    onSubmit(data)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {purchase ? t("purchase.edit") : t("purchase.create")}
+          </DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            {purchaseFields.map((field) => (
+              <FormFieldRenderer<PurchaseFormData> key={field.key} config={field} control={form.control} />
+            ))}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                {t("common.cancel")}
+              </Button>
+              <Button type="submit">{t("common.save")}</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/purchases-table.tsx
+++ b/frontend/src/components/purchases-table.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { format } from "date-fns"
+import { ChevronRight, ExternalLink, FileText, BookOpen, MoreVertical } from "lucide-react"
+import type { Purchase } from "@/types/purchase"
+import { purchaseFields } from "@/config/purchase-fields"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Collapsible,
+  CollapsibleContent,
+} from "@/components/ui/collapsible"
+import { cn } from "@/lib/utils"
+
+const tableColumns = purchaseFields
+  .filter((f) => f.showInTable)
+  .sort((a, b) => a.tableOrder - b.tableOrder)
+
+const detailFields = purchaseFields.filter((f) => !f.showInTable)
+
+interface PurchasesTableProps {
+  purchases: Purchase[]
+  onEdit: (purchase: Purchase) => void
+  onDelete: (purchase: Purchase) => void
+}
+
+function formatCellValue(purchase: Purchase, key: string, currency: string): string {
+  const value = purchase[key as keyof Purchase]
+  if (value === undefined || value === null || value === "") return "-"
+  if (key === "price") return `${Number(value).toFixed(2)} ${currency}`
+  if (key === "purchaseDate") return format(new Date(value as string), "yyyy-MM-dd")
+  return String(value)
+}
+
+interface PurchaseDetailRowProps {
+  purchase: Purchase
+  colSpan: number
+}
+
+function PurchaseDetailRow({ purchase, colSpan }: PurchaseDetailRowProps) {
+  const { t } = useTranslation()
+  const currency = t("common.currency")
+
+  return (
+    <TableRow className="bg-muted/30 hover:bg-muted/30">
+      <TableCell colSpan={colSpan} className="p-0">
+        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapse data-[state=open]:animate-expand">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+            {detailFields.map((field) => {
+              const value = formatCellValue(purchase, field.key, currency)
+              if (value === "-" && field.type === "textarea") return null
+              return (
+                <div key={field.key} className={cn(field.type === "textarea" ? "col-span-full" : "")}>
+                  <div className="text-xs text-muted-foreground">{t(field.i18nKey)}</div>
+                  <div className={cn("text-sm", field.type === "textarea" && "whitespace-pre-wrap")}>
+                    {field.type === "url" && value !== "-" ? (
+                      <a
+                        href={value}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline break-all"
+                      >
+                        {value}
+                      </a>
+                    ) : (
+                      value
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CollapsibleContent>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function PurchasesTable({ purchases, onEdit, onDelete }: PurchasesTableProps) {
+  const { t } = useTranslation()
+  const currency = t("common.currency")
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const totalColumns = tableColumns.length + 3 // +1 chevron, +1 links, +1 actions
+
+  const toggleExpand = (id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id))
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-10" />
+            {tableColumns.map((col) => (
+              <TableHead key={col.key}>{t(col.i18nKey)}</TableHead>
+            ))}
+            <TableHead>{t("purchase.links")}</TableHead>
+            <TableHead className="w-12" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {purchases.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={totalColumns} className="text-center text-muted-foreground py-8">
+                {t("purchase.noPurchases")}
+              </TableCell>
+            </TableRow>
+          ) : (
+            purchases.map((purchase) => {
+              const isExpanded = expandedId === purchase.id
+              return (
+                <Collapsible key={purchase.id} open={isExpanded} asChild>
+                  <>
+                    <TableRow
+                      className="cursor-pointer select-none"
+                      onClick={() => toggleExpand(purchase.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault()
+                          toggleExpand(purchase.id)
+                        }
+                      }}
+                      tabIndex={0}
+                    >
+                      <TableCell className="w-10">
+                        <ChevronRight
+                          className={cn(
+                            "h-4 w-4 transition-transform duration-200",
+                            isExpanded && "rotate-90"
+                          )}
+                        />
+                      </TableCell>
+                      {tableColumns.map((col) => (
+                        <TableCell key={col.key}>{formatCellValue(purchase, col.key, currency)}</TableCell>
+                      ))}
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <div className="flex gap-1">
+                          {purchase.descriptionUrl && (
+                            <a href={purchase.descriptionUrl} target="_blank" rel="noopener noreferrer">
+                              <Button variant="ghost" size="icon" className="h-8 w-8" title={t("purchaseFields.descriptionUrl")}>
+                                <ExternalLink className="h-4 w-4" />
+                              </Button>
+                            </a>
+                          )}
+                          {purchase.invoiceUrl && (
+                            <a href={purchase.invoiceUrl} target="_blank" rel="noopener noreferrer">
+                              <Button variant="ghost" size="icon" className="h-8 w-8" title={t("purchaseFields.invoiceUrl")}>
+                                <FileText className="h-4 w-4" />
+                              </Button>
+                            </a>
+                          )}
+                          {purchase.handbookUrl && (
+                            <a href={purchase.handbookUrl} target="_blank" rel="noopener noreferrer">
+                              <Button variant="ghost" size="icon" className="h-8 w-8" title={t("purchaseFields.handbookUrl")}>
+                                <BookOpen className="h-4 w-4" />
+                              </Button>
+                            </a>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" className="h-8 w-8">
+                              <MoreVertical className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => onEdit(purchase)}>
+                              {t("common.edit")}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => onDelete(purchase)} className="text-destructive">
+                              {t("common.delete")}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </TableCell>
+                    </TableRow>
+                    <PurchaseDetailRow purchase={purchase} colSpan={totalColumns} />
+                  </>
+                </Collapsible>
+              )
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/frontend/src/components/purchases-table.tsx
+++ b/frontend/src/components/purchases-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { format } from "date-fns"
 import { ChevronRight, ExternalLink, FileText, BookOpen, MoreVertical } from "lucide-react"
@@ -19,10 +19,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import {
-  Collapsible,
-  CollapsibleContent,
-} from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 
 const tableColumns = purchaseFields
@@ -57,8 +53,7 @@ function PurchaseDetailRow({ purchase, colSpan }: PurchaseDetailRowProps) {
   return (
     <TableRow className="bg-muted/30 hover:bg-muted/30">
       <TableCell colSpan={colSpan} className="p-0">
-        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapse data-[state=open]:animate-expand">
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
             {detailFields.map((field) => {
               const value = formatCellValue(purchase, field.key, currency)
               if (value === "-" && field.type === "textarea") return null
@@ -83,7 +78,6 @@ function PurchaseDetailRow({ purchase, colSpan }: PurchaseDetailRowProps) {
               )
             })}
           </div>
-        </CollapsibleContent>
       </TableCell>
     </TableRow>
   )
@@ -124,8 +118,7 @@ export function PurchasesTable({ purchases, onEdit, onDelete }: PurchasesTablePr
             purchases.map((purchase) => {
               const isExpanded = expandedId === purchase.id
               return (
-                <Collapsible key={purchase.id} open={isExpanded} asChild>
-                  <>
+                <Fragment key={purchase.id}>
                     <TableRow
                       className="cursor-pointer select-none"
                       onClick={() => toggleExpand(purchase.id)}
@@ -191,9 +184,8 @@ export function PurchasesTable({ purchases, onEdit, onDelete }: PurchasesTablePr
                         </DropdownMenu>
                       </TableCell>
                     </TableRow>
-                    <PurchaseDetailRow purchase={purchase} colSpan={totalColumns} />
-                  </>
-                </Collapsible>
+                    {isExpanded && <PurchaseDetailRow purchase={purchase} colSpan={totalColumns} />}
+                </Fragment>
               )
             })
           )}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -1,14 +1,42 @@
+import { useState } from "react"
 import { Link, useMatchRoute } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { useCategories } from "@/hooks/use-categories"
 import { cn } from "@/lib/utils"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { ChevronRight, Home } from "lucide-react"
+
+function SidebarSection({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-1 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors">
+        <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} />
+        {title}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="flex flex-col gap-1">
+          {children}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
 
 export function Sidebar() {
   const { t } = useTranslation()
-  const { data: categories = [] } = useCategories()
+  const { data: contractCategories = [] } = useCategories("contracts")
+  const { data: purchaseCategories = [] } = useCategories("purchases")
   const matchRoute = useMatchRoute()
-
-  const isDashboard = matchRoute({ to: "/" })
 
   return (
     <aside className="w-64 shrink-0 border-r bg-background">
@@ -16,56 +44,101 @@ export function Sidebar() {
         <Link
           to="/"
           className={cn(
-            "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-            isDashboard && "bg-accent",
+            "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+            matchRoute({ to: "/" }) && "bg-accent",
           )}
         >
-          {t("nav.dashboard")}
+          <Home className="h-4 w-4" />
+          {t("home.title")}
         </Link>
 
-        <Link
-          to="/upcoming-renewals"
-          className={cn(
-            "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-            matchRoute({ to: "/upcoming-renewals" }) && "bg-accent",
-          )}
-        >
-          {t("nav.upcomingRenewals")}
-        </Link>
+        <div className="my-2" />
 
-        <Link
-          to="/settings"
-          className={cn(
-            "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-            matchRoute({ to: "/settings" }) && "bg-accent",
-          )}
-        >
-          {t("nav.settings")}
-        </Link>
+        <SidebarSection title={t("nav.contracts")}>
+          <Link
+            to="/contracts"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+              matchRoute({ to: "/contracts" }) && "bg-accent",
+            )}
+          >
+            {t("nav.dashboard")}
+          </Link>
 
-        <h2 className="mt-4 mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          {t("nav.categories")}
-        </h2>
+          <Link
+            to="/contracts/upcoming-renewals"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+              matchRoute({ to: "/contracts/upcoming-renewals" }) && "bg-accent",
+            )}
+          >
+            {t("nav.upcomingRenewals")}
+          </Link>
 
-        {categories.map((category) => {
-          const isActive = matchRoute({
-            to: "/categories/$categoryId",
-            params: { categoryId: category.id },
-          })
-          return (
-            <Link
-              key={category.id}
-              to="/categories/$categoryId"
-              params={{ categoryId: category.id }}
-              className={cn(
-                "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent",
-                isActive && "bg-accent font-medium",
-              )}
-            >
-              {category.nameKey ? t(category.nameKey) : category.name}
-            </Link>
-          )
-        })}
+          {contractCategories.map((category) => {
+            const isActive = matchRoute({
+              to: "/contracts/categories/$categoryId",
+              params: { categoryId: category.id },
+            })
+            return (
+              <Link
+                key={category.id}
+                to="/contracts/categories/$categoryId"
+                params={{ categoryId: category.id }}
+                className={cn(
+                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent pl-6",
+                  isActive && "bg-accent font-medium",
+                )}
+              >
+                {category.nameKey ? t(category.nameKey) : category.name}
+              </Link>
+            )
+          })}
+        </SidebarSection>
+
+        <SidebarSection title={t("nav.purchases")}>
+          <Link
+            to="/purchases"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+              matchRoute({ to: "/purchases" }) && "bg-accent",
+            )}
+          >
+            {t("nav.dashboard")}
+          </Link>
+
+          {purchaseCategories.map((category) => {
+            const isActive = matchRoute({
+              to: "/purchases/categories/$categoryId",
+              params: { categoryId: category.id },
+            })
+            return (
+              <Link
+                key={category.id}
+                to="/purchases/categories/$categoryId"
+                params={{ categoryId: category.id }}
+                className={cn(
+                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent pl-6",
+                  isActive && "bg-accent font-medium",
+                )}
+              >
+                {category.nameKey ? t(category.nameKey) : category.name}
+              </Link>
+            )
+          })}
+        </SidebarSection>
+
+        <SidebarSection title={t("nav.general")}>
+          <Link
+            to="/settings"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+              matchRoute({ to: "/settings" }) && "bg-accent",
+            )}
+          >
+            {t("nav.settings")}
+          </Link>
+        </SidebarSection>
       </nav>
     </aside>
   )

--- a/frontend/src/config/purchase-fields.ts
+++ b/frontend/src/config/purchase-fields.ts
@@ -1,0 +1,16 @@
+import type { FieldConfig } from "./contract-fields"
+
+export const purchaseFields: FieldConfig[] = [
+  { key: "itemName", type: "text", i18nKey: "purchaseFields.itemName", required: true, showInTable: true, tableOrder: 0 },
+  { key: "type", type: "text", i18nKey: "purchaseFields.type", required: false, showInTable: true, tableOrder: 1 },
+  { key: "brand", type: "text", i18nKey: "purchaseFields.brand", required: false, showInTable: true, tableOrder: 2 },
+  { key: "dealer", type: "text", i18nKey: "purchaseFields.dealer", required: false, showInTable: true, tableOrder: 3 },
+  { key: "price", type: "number", i18nKey: "purchaseFields.price", required: false, showInTable: true, tableOrder: 4 },
+  { key: "purchaseDate", type: "date", i18nKey: "purchaseFields.purchaseDate", required: false, showInTable: true, tableOrder: 5 },
+  { key: "articleNumber", type: "text", i18nKey: "purchaseFields.articleNumber", required: false, showInTable: false, tableOrder: -1 },
+  { key: "descriptionUrl", type: "url", i18nKey: "purchaseFields.descriptionUrl", required: false, showInTable: false, tableOrder: -1 },
+  { key: "invoiceUrl", type: "url", i18nKey: "purchaseFields.invoiceUrl", required: false, showInTable: false, tableOrder: -1 },
+  { key: "handbookUrl", type: "url", i18nKey: "purchaseFields.handbookUrl", required: false, showInTable: false, tableOrder: -1 },
+  { key: "consumables", type: "textarea", i18nKey: "purchaseFields.consumables", required: false, showInTable: false, tableOrder: -1 },
+  { key: "comments", type: "textarea", i18nKey: "purchaseFields.comments", required: false, showInTable: false, tableOrder: -1 },
+]

--- a/frontend/src/hooks/use-categories.ts
+++ b/frontend/src/hooks/use-categories.ts
@@ -7,35 +7,35 @@ import {
 } from "@/lib/category-repository"
 import type { CategoryFormData } from "@/types/category"
 
-const CATEGORIES_KEY = ["categories"] as const
+const categoriesKey = (module: string) => ["categories", module] as const
 
-export function useCategories() {
+export function useCategories(module: string) {
   return useQuery({
-    queryKey: CATEGORIES_KEY,
-    queryFn: getAllCategories,
+    queryKey: categoriesKey(module),
+    queryFn: () => getAllCategories(module),
   })
 }
 
-export function useCreateCategory() {
+export function useCreateCategory(module: string) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (data: CategoryFormData) => createCategory(data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: CATEGORIES_KEY }),
+    mutationFn: (data: CategoryFormData) => createCategory(module, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: categoriesKey(module) }),
   })
 }
 
-export function useUpdateCategory() {
+export function useUpdateCategory(module: string) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: CategoryFormData }) => updateCategory(id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: CATEGORIES_KEY }),
+    mutationFn: ({ id, data }: { id: string; data: CategoryFormData }) => updateCategory(module, id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: categoriesKey(module) }),
   })
 }
 
-export function useDeleteCategory() {
+export function useDeleteCategory(module: string) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) => deleteCategory(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: CATEGORIES_KEY }),
+    mutationFn: (id: string) => deleteCategory(module, id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: categoriesKey(module) }),
   })
 }

--- a/frontend/src/hooks/use-categories.ts
+++ b/frontend/src/hooks/use-categories.ts
@@ -36,6 +36,13 @@ export function useDeleteCategory(module: string) {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => deleteCategory(module, id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: categoriesKey(module) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: categoriesKey(module) })
+      if (module === "contracts") {
+        qc.invalidateQueries({ queryKey: ["summary"] })
+      } else if (module === "purchases") {
+        qc.invalidateQueries({ queryKey: ["purchases-summary"] })
+      }
+    },
   })
 }

--- a/frontend/src/hooks/use-contracts.ts
+++ b/frontend/src/hooks/use-contracts.ts
@@ -31,7 +31,8 @@ export function useCreateContract(categoryId: string) {
     mutationFn: (data: ContractFormData) => createContract(categoryId, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: contractsKey(categoryId) })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      qc.invalidateQueries({ queryKey: ["summary"] })
     },
   })
 }
@@ -42,7 +43,8 @@ export function useUpdateContract(categoryId: string) {
     mutationFn: ({ id, data }: { id: string; data: ContractFormData }) => updateContract(id, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: contractsKey(categoryId) })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      qc.invalidateQueries({ queryKey: ["summary"] })
     },
   })
 }
@@ -53,7 +55,8 @@ export function useDeleteContract(categoryId: string) {
     mutationFn: (id: string) => deleteContract(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: contractsKey(categoryId) })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      qc.invalidateQueries({ queryKey: ["summary"] })
     },
   })
 }
@@ -64,7 +67,7 @@ export function useImportContracts() {
     mutationFn: (file: File) => importContracts(file),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contracts"] })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
       qc.invalidateQueries({ queryKey: ["summary"] })
     },
   })

--- a/frontend/src/hooks/use-purchases.ts
+++ b/frontend/src/hooks/use-purchases.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  getPurchasesByCategory,
+  createPurchase,
+  updatePurchase,
+  deletePurchase,
+} from "@/lib/purchase-repository"
+import type { PurchaseFormData } from "@/types/purchase"
+
+const purchasesKey = (categoryId: string) => ["purchases", categoryId] as const
+
+export function useCategoryPurchases(categoryId: string) {
+  return useQuery({
+    queryKey: purchasesKey(categoryId),
+    queryFn: () => getPurchasesByCategory(categoryId),
+  })
+}
+
+export function useCreatePurchase(categoryId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: PurchaseFormData) => createPurchase(categoryId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: purchasesKey(categoryId) })
+      qc.invalidateQueries({ queryKey: ["categories", "purchases"] })
+      qc.invalidateQueries({ queryKey: ["purchases-summary"] })
+    },
+  })
+}
+
+export function useUpdatePurchase(categoryId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: PurchaseFormData }) => updatePurchase(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: purchasesKey(categoryId) })
+      qc.invalidateQueries({ queryKey: ["categories", "purchases"] })
+      qc.invalidateQueries({ queryKey: ["purchases-summary"] })
+    },
+  })
+}
+
+export function useDeletePurchase(categoryId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => deletePurchase(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: purchasesKey(categoryId) })
+      qc.invalidateQueries({ queryKey: ["categories", "purchases"] })
+      qc.invalidateQueries({ queryKey: ["purchases-summary"] })
+    },
+  })
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2,11 +2,24 @@
   "app": {
     "title": "Verträge"
   },
+  "home": {
+    "title": "Übersicht",
+    "activeContracts": "Aktive Verträge",
+    "monthlySpend": "Monatliche Kosten",
+    "totalPurchases": "Anschaffungen gesamt",
+    "totalSpent": "Ausgaben gesamt",
+    "quickStats": "Kurzübersicht",
+    "yearlyContracts": "Jährliche Verträge",
+    "categories": "Kategorien"
+  },
   "nav": {
     "dashboard": "Dashboard",
+    "contracts": "Verträge",
+    "purchases": "Anschaffungen",
     "upcomingRenewals": "Anstehende Verlängerungen",
     "settings": "Einstellungen",
     "categories": "Kategorien",
+    "general": "Allgemein",
     "language": "Sprache",
     "en": "English",
     "de": "Deutsch"
@@ -24,7 +37,7 @@
     "create": "Kategorie erstellen",
     "edit": "Kategorie bearbeiten",
     "delete": "Kategorie löschen",
-    "deleteConfirm": "Die Kategorie \"{{name}}\" und alle zugehörigen Verträge werden unwiderruflich gelöscht.",
+    "deleteConfirm": "Die Kategorie \"{{name}}\" und alle zugehörigen Einträge werden unwiderruflich gelöscht.",
     "name": "Name",
     "namePlaceholder": "z.B. Versicherung",
     "created": "Kategorie erstellt.",
@@ -46,6 +59,20 @@
     "backToDashboard": "Dashboard",
     "links": "Links"
   },
+  "purchase": {
+    "create": "Anschaffung hinzufügen",
+    "edit": "Anschaffung bearbeiten",
+    "delete": "Anschaffung löschen",
+    "deleteConfirm": "Die Anschaffung \"{{name}}\" wird unwiderruflich gelöscht.",
+    "noPurchases": "Noch keine Anschaffungen in dieser Kategorie.",
+    "created": "Anschaffung erstellt.",
+    "updated": "Anschaffung aktualisiert.",
+    "deleted": "Anschaffung gelöscht.",
+    "links": "Links",
+    "purchaseCount_one": "{{count}} Anschaffung",
+    "purchaseCount_other": "{{count}} Anschaffungen",
+    "totalSpent": "Gesamt: {{amount}}"
+  },
   "fields": {
     "name": "Vertragsname",
     "productName": "Produkt",
@@ -66,10 +93,29 @@
     "paperlessUrl": "Paperless-URL",
     "comments": "Kommentare"
   },
+  "purchaseFields": {
+    "itemName": "Artikelname",
+    "type": "Typ",
+    "brand": "Marke",
+    "articleNumber": "Artikelnr.",
+    "dealer": "Händler",
+    "price": "Preis",
+    "purchaseDate": "Kaufdatum",
+    "descriptionUrl": "Produktseite-URL",
+    "invoiceUrl": "Rechnung-URL",
+    "handbookUrl": "Handbuch-URL",
+    "consumables": "Verbrauchsmaterial",
+    "comments": "Kommentare"
+  },
   "categoryNames": {
     "insurance": "Versicherung",
     "banking": "Banking / Portfolios",
-    "telecommunications": "Telekommunikation"
+    "telecommunications": "Telekommunikation",
+    "pcHardware": "PC-Hardware",
+    "entertainment": "Unterhaltung",
+    "kitchen": "Küche",
+    "tools": "Werkzeuge",
+    "household": "Haushalt"
   },
   "auth": {
     "login": "Anmelden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2,11 +2,24 @@
   "app": {
     "title": "Contracts"
   },
+  "home": {
+    "title": "Overview",
+    "activeContracts": "Active contracts",
+    "monthlySpend": "Monthly spend",
+    "totalPurchases": "Total purchases",
+    "totalSpent": "Total spent",
+    "quickStats": "Quick Stats",
+    "yearlyContracts": "Yearly contracts",
+    "categories": "Categories"
+  },
   "nav": {
     "dashboard": "Dashboard",
+    "contracts": "Contracts",
+    "purchases": "Purchases",
     "upcomingRenewals": "Upcoming Renewals",
     "settings": "Settings",
     "categories": "Categories",
+    "general": "General",
     "language": "Language",
     "en": "English",
     "de": "Deutsch"
@@ -24,7 +37,7 @@
     "create": "Create Category",
     "edit": "Edit Category",
     "delete": "Delete Category",
-    "deleteConfirm": "This will permanently delete the category \"{{name}}\" and all its contracts.",
+    "deleteConfirm": "This will permanently delete the category \"{{name}}\" and all its items.",
     "name": "Name",
     "namePlaceholder": "e.g. Insurance",
     "created": "Category created.",
@@ -46,6 +59,20 @@
     "backToDashboard": "Dashboard",
     "links": "Links"
   },
+  "purchase": {
+    "create": "Add Purchase",
+    "edit": "Edit Purchase",
+    "delete": "Delete Purchase",
+    "deleteConfirm": "This will permanently delete the purchase \"{{name}}\".",
+    "noPurchases": "No purchases in this category yet.",
+    "created": "Purchase created.",
+    "updated": "Purchase updated.",
+    "deleted": "Purchase deleted.",
+    "links": "Links",
+    "purchaseCount_one": "{{count}} purchase",
+    "purchaseCount_other": "{{count}} purchases",
+    "totalSpent": "Total: {{amount}}"
+  },
   "fields": {
     "name": "Contract Name",
     "productName": "Product",
@@ -66,10 +93,29 @@
     "paperlessUrl": "Paperless URL",
     "comments": "Comments"
   },
+  "purchaseFields": {
+    "itemName": "Item Name",
+    "type": "Type",
+    "brand": "Brand",
+    "articleNumber": "Article No.",
+    "dealer": "Dealer",
+    "price": "Price",
+    "purchaseDate": "Purchase Date",
+    "descriptionUrl": "Product Page URL",
+    "invoiceUrl": "Invoice URL",
+    "handbookUrl": "Handbook URL",
+    "consumables": "Consumables",
+    "comments": "Comments"
+  },
   "categoryNames": {
     "insurance": "Insurance",
     "banking": "Banking / Portfolios",
-    "telecommunications": "Telecommunications"
+    "telecommunications": "Telecommunications",
+    "pcHardware": "PC Hardware",
+    "entertainment": "Entertainment",
+    "kitchen": "Kitchen",
+    "tools": "Tools",
+    "household": "Household"
   },
   "auth": {
     "login": "Sign In",

--- a/frontend/src/lib/category-repository.ts
+++ b/frontend/src/lib/category-repository.ts
@@ -1,22 +1,22 @@
 import type { Category, CategoryFormData } from "@/types/category"
 import { del, get, post, put } from "./api"
 
-export async function getAllCategories(): Promise<Category[]> {
-  return get<Category[]>("/categories")
+export async function getAllCategories(module: string): Promise<Category[]> {
+  return get<Category[]>(`/modules/${module}/categories`)
 }
 
-export async function getCategoryById(id: string): Promise<Category | undefined> {
-  return get<Category>(`/categories/${id}`)
+export async function getCategoryById(module: string, id: string): Promise<Category | undefined> {
+  return get<Category>(`/modules/${module}/categories/${id}`)
 }
 
-export async function createCategory(data: CategoryFormData): Promise<Category> {
-  return post<Category>("/categories", data)
+export async function createCategory(module: string, data: CategoryFormData): Promise<Category> {
+  return post<Category>(`/modules/${module}/categories`, data)
 }
 
-export async function updateCategory(id: string, data: CategoryFormData): Promise<Category> {
-  return put<Category>(`/categories/${id}`, data)
+export async function updateCategory(module: string, id: string, data: CategoryFormData): Promise<Category> {
+  return put<Category>(`/modules/${module}/categories/${id}`, data)
 }
 
-export async function deleteCategory(id: string): Promise<void> {
-  return del(`/categories/${id}`)
+export async function deleteCategory(module: string, id: string): Promise<void> {
+  return del(`/modules/${module}/categories/${id}`)
 }

--- a/frontend/src/lib/category-repository.ts
+++ b/frontend/src/lib/category-repository.ts
@@ -5,7 +5,7 @@ export async function getAllCategories(module: string): Promise<Category[]> {
   return get<Category[]>(`/modules/${module}/categories`)
 }
 
-export async function getCategoryById(module: string, id: string): Promise<Category | undefined> {
+export async function getCategoryById(module: string, id: string): Promise<Category> {
   return get<Category>(`/modules/${module}/categories/${id}`)
 }
 

--- a/frontend/src/lib/contract-repository.ts
+++ b/frontend/src/lib/contract-repository.ts
@@ -15,7 +15,7 @@ export async function getContractsByCategory(categoryId: string): Promise<Contra
   return get<Contract[]>(`/categories/${categoryId}/contracts`)
 }
 
-export async function getContractById(id: string): Promise<Contract | undefined> {
+export async function getContractById(id: string): Promise<Contract> {
   return get<Contract>(`/contracts/${id}`)
 }
 

--- a/frontend/src/lib/purchase-repository.ts
+++ b/frontend/src/lib/purchase-repository.ts
@@ -9,7 +9,7 @@ export async function getPurchasesByCategory(categoryId: string): Promise<Purcha
   return get<Purchase[]>(`/categories/${categoryId}/purchases`)
 }
 
-export async function getPurchaseById(id: string): Promise<Purchase | undefined> {
+export async function getPurchaseById(id: string): Promise<Purchase> {
   return get<Purchase>(`/purchases/${id}`)
 }
 

--- a/frontend/src/lib/purchase-repository.ts
+++ b/frontend/src/lib/purchase-repository.ts
@@ -1,0 +1,30 @@
+import type { Purchase, PurchaseFormData, PurchaseSummary } from "@/types/purchase"
+import { del, get, post, put } from "./api"
+
+export async function getAllPurchases(): Promise<Purchase[]> {
+  return get<Purchase[]>("/purchases")
+}
+
+export async function getPurchasesByCategory(categoryId: string): Promise<Purchase[]> {
+  return get<Purchase[]>(`/categories/${categoryId}/purchases`)
+}
+
+export async function getPurchaseById(id: string): Promise<Purchase | undefined> {
+  return get<Purchase>(`/purchases/${id}`)
+}
+
+export async function createPurchase(categoryId: string, data: PurchaseFormData): Promise<Purchase> {
+  return post<Purchase>(`/categories/${categoryId}/purchases`, data)
+}
+
+export async function updatePurchase(id: string, data: PurchaseFormData): Promise<Purchase> {
+  return put<Purchase>(`/purchases/${id}`, data)
+}
+
+export async function deletePurchase(id: string): Promise<void> {
+  return del(`/purchases/${id}`)
+}
+
+export async function getPurchaseSummary(): Promise<PurchaseSummary> {
+  return get<PurchaseSummary>("/purchases/summary")
+}

--- a/frontend/src/routes/contracts.categories.$categoryId.tsx
+++ b/frontend/src/routes/contracts.categories.$categoryId.tsx
@@ -14,18 +14,18 @@ import { ContractsTable } from "@/components/contracts-table"
 import { ContractDialog } from "@/components/contract-dialog"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
 
-export const categoryRoute = createRoute({
+export const contractsCategoryRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/categories/$categoryId",
-  component: CategoryDetailPage,
+  path: "/contracts/categories/$categoryId",
+  component: ContractsCategoryDetailPage,
 })
 
-function CategoryDetailPage() {
+function ContractsCategoryDetailPage() {
   const { t } = useTranslation()
-  const { categoryId } = categoryRoute.useParams()
+  const { categoryId } = contractsCategoryRoute.useParams()
   const { data: category } = useQuery({
-    queryKey: ["category", categoryId],
-    queryFn: () => getCategoryById(categoryId),
+    queryKey: ["category", "contracts", categoryId],
+    queryFn: () => getCategoryById("contracts", categoryId),
   })
   const categoryName = category ? (category.nameKey ? t(category.nameKey) : category.name) : t("nav.categories")
   usePageTitle(categoryName, t("app.title"))

--- a/frontend/src/routes/contracts.index.tsx
+++ b/frontend/src/routes/contracts.index.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react"
+import { createRoute } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
+import { usePageTitle } from "@/hooks/use-page-title"
+import { toast } from "sonner"
+import { Plus, Upload } from "lucide-react"
+import { rootRoute } from "./__root"
+import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from "@/hooks/use-categories"
+import { getSummary } from "@/lib/contract-repository"
+import { useQuery } from "@tanstack/react-query"
+import type { Category, CategoryFormData } from "@/types/category"
+import { Button } from "@/components/ui/button"
+import { CategoryCard } from "@/components/category-card"
+import { CategoryDialog } from "@/components/category-dialog"
+import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
+import { ImportDialog } from "@/components/import-dialog"
+
+export const contractsIndexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/contracts",
+  component: ContractsDashboardPage,
+})
+
+function ContractsDashboardPage() {
+  const { t } = useTranslation()
+  usePageTitle(t("nav.contracts"), t("app.title"))
+  const { data: categories = [] } = useCategories("contracts")
+  const { data: summary } = useQuery({
+    queryKey: ["summary"],
+    queryFn: getSummary,
+  })
+  const summaryByCategory = new Map(
+    (summary?.categories ?? []).map((s) => [s.id, s]),
+  )
+  const createCategory = useCreateCategory("contracts")
+  const updateCategory = useUpdateCategory("contracts")
+  const deleteCategory = useDeleteCategory("contracts")
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null)
+  const [deletingCategory, setDeletingCategory] = useState<Category | null>(null)
+
+  function handleCreate(data: CategoryFormData) {
+    createCategory.mutate(data, { onSuccess: () => toast.success(t("category.created")) })
+  }
+
+  function handleUpdate(data: CategoryFormData) {
+    if (!editingCategory) return
+    updateCategory.mutate(
+      { id: editingCategory.id, data },
+      { onSuccess: () => toast.success(t("category.updated")) },
+    )
+    setEditingCategory(null)
+  }
+
+  function handleDelete() {
+    if (!deletingCategory) return
+    deleteCategory.mutate(deletingCategory.id, {
+      onSuccess: () => toast.success(t("category.deleted")),
+    })
+    setDeletingCategory(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t("nav.contracts")}</h1>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setImportOpen(true)}>
+            <Upload className="mr-2 h-4 w-4" />
+            {t("import.button")}
+          </Button>
+          <Button onClick={() => setDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("dashboard.newCategory")}
+          </Button>
+        </div>
+      </div>
+
+      {categories.length === 0 ? (
+        <p className="text-muted-foreground">{t("dashboard.noCategories")}</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {categories.map((cat) => {
+            const catSummary = summaryByCategory.get(cat.id)
+            return (
+              <CategoryCard
+                key={cat.id}
+                category={cat}
+                module="contracts"
+                totalAmount={catSummary?.monthlyTotal ?? 0}
+                secondaryAmount={catSummary?.yearlyTotal ?? 0}
+                itemLabel={t("dashboard.contractCount", { count: catSummary?.contractCount ?? 0 })}
+                totalLabel={t("dashboard.monthlyTotal", {
+                  amount: `${(catSummary?.monthlyTotal ?? 0).toFixed(2)} ${t("common.currency")}`,
+                })}
+                secondaryLabel={t("dashboard.yearlyTotal", {
+                  amount: `${(catSummary?.yearlyTotal ?? 0).toFixed(2)} ${t("common.currency")}`,
+                })}
+                onEdit={() => setEditingCategory(cat)}
+                onDelete={() => setDeletingCategory(cat)}
+              />
+            )
+          })}
+        </div>
+      )}
+
+      <CategoryDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleCreate}
+      />
+
+      <CategoryDialog
+        open={!!editingCategory}
+        onOpenChange={(open) => { if (!open) setEditingCategory(null) }}
+        category={editingCategory}
+        onSubmit={handleUpdate}
+      />
+
+      <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
+
+      <DeleteConfirmDialog
+        open={!!deletingCategory}
+        onOpenChange={(open) => { if (!open) setDeletingCategory(null) }}
+        description={t("category.deleteConfirm", { name: deletingCategory?.nameKey ? t(deletingCategory.nameKey) : deletingCategory?.name ?? "" })}
+        onConfirm={handleDelete}
+      />
+    </div>
+  )
+}

--- a/frontend/src/routes/contracts.upcoming-renewals.tsx
+++ b/frontend/src/routes/contracts.upcoming-renewals.tsx
@@ -14,9 +14,9 @@ import { ContractsTable } from "@/components/contracts-table"
 import { ContractDialog } from "@/components/contract-dialog"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
 
-export const upcomingRenewalsRoute = createRoute({
+export const contractsUpcomingRenewalsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/upcoming-renewals",
+  path: "/contracts/upcoming-renewals",
   component: UpcomingRenewalsPage,
 })
 
@@ -34,7 +34,7 @@ function UpcomingRenewalsPage() {
     mutationFn: ({ id, data }: { id: string; data: ContractFormData }) => updateContract(id, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contracts"] })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
       toast.success(t("contract.updated"))
       setEditingContract(null)
     },
@@ -44,7 +44,7 @@ function UpcomingRenewalsPage() {
     mutationFn: ({ id }: { id: string }) => deleteContract(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contracts"] })
-      qc.invalidateQueries({ queryKey: ["categories"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
       toast.success(t("contract.deleted"))
       setDeletingContract(null)
     },
@@ -63,14 +63,8 @@ function UpcomingRenewalsPage() {
   function getRowClass(c: Contract) {
     if (!c.cancellationDate) return undefined
     const days = differenceInDays(new Date(c.cancellationDate), new Date())
-    
-    // Very close/Urgent (<= 30 days) - Red
     if (days <= 30) return "bg-destructive/10 hover:bg-destructive/20"
-    
-    // Approaching (<= 90 days) - Yellow
     if (days <= 90) return "bg-yellow-500/10 hover:bg-yellow-500/20"
-    
-    // Far off (> 90 days) - Greyed out / less prominent
     return "text-muted-foreground opacity-75"
   }
 

--- a/frontend/src/routes/purchases.categories.$categoryId.tsx
+++ b/frontend/src/routes/purchases.categories.$categoryId.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react"
+import { createRoute } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
+import { usePageTitle } from "@/hooks/use-page-title"
+import { toast } from "sonner"
+import { Plus } from "lucide-react"
+import { rootRoute } from "./__root"
+import { useCategoryPurchases, useCreatePurchase, useUpdatePurchase, useDeletePurchase } from "@/hooks/use-purchases"
+import { getCategoryById } from "@/lib/category-repository"
+import { useQuery } from "@tanstack/react-query"
+import type { Purchase, PurchaseFormData } from "@/types/purchase"
+import { Button } from "@/components/ui/button"
+import { PurchasesTable } from "@/components/purchases-table"
+import { PurchaseDialog } from "@/components/purchase-dialog"
+import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
+
+export const purchasesCategoryRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/purchases/categories/$categoryId",
+  component: PurchasesCategoryDetailPage,
+})
+
+function PurchasesCategoryDetailPage() {
+  const { t } = useTranslation()
+  const { categoryId } = purchasesCategoryRoute.useParams()
+  const { data: category } = useQuery({
+    queryKey: ["category", "purchases", categoryId],
+    queryFn: () => getCategoryById("purchases", categoryId),
+  })
+  const categoryName = category ? (category.nameKey ? t(category.nameKey) : category.name) : t("nav.categories")
+  usePageTitle(categoryName, t("app.title"))
+  const { data: purchases = [] } = useCategoryPurchases(categoryId)
+  const createPurchase = useCreatePurchase(categoryId)
+  const updatePurchase = useUpdatePurchase(categoryId)
+  const deletePurchase = useDeletePurchase(categoryId)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingPurchase, setEditingPurchase] = useState<Purchase | null>(null)
+  const [deletingPurchase, setDeletingPurchase] = useState<Purchase | null>(null)
+
+  function handleCreate(data: PurchaseFormData) {
+    createPurchase.mutate(data, { onSuccess: () => toast.success(t("purchase.created")) })
+  }
+
+  function handleUpdate(data: PurchaseFormData) {
+    if (!editingPurchase) return
+    updatePurchase.mutate(
+      { id: editingPurchase.id, data },
+      { onSuccess: () => toast.success(t("purchase.updated")) },
+    )
+    setEditingPurchase(null)
+  }
+
+  function handleDelete() {
+    if (!deletingPurchase) return
+    deletePurchase.mutate(deletingPurchase.id, {
+      onSuccess: () => toast.success(t("purchase.deleted")),
+    })
+    setDeletingPurchase(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <h1 className="text-2xl font-bold">
+          {category ? (category.nameKey ? t(category.nameKey) : category.name) : "..."}
+        </h1>
+        <div className="ml-auto">
+          <Button onClick={() => setDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("purchase.create")}
+          </Button>
+        </div>
+      </div>
+
+      <PurchasesTable
+        purchases={purchases}
+        onEdit={(p) => setEditingPurchase(p)}
+        onDelete={(p) => setDeletingPurchase(p)}
+      />
+
+      <PurchaseDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleCreate}
+      />
+
+      <PurchaseDialog
+        open={!!editingPurchase}
+        onOpenChange={(open) => { if (!open) setEditingPurchase(null) }}
+        purchase={editingPurchase}
+        onSubmit={handleUpdate}
+      />
+
+      <DeleteConfirmDialog
+        open={!!deletingPurchase}
+        onOpenChange={(open) => { if (!open) setDeletingPurchase(null) }}
+        description={t("purchase.deleteConfirm", { name: deletingPurchase?.itemName ?? "" })}
+        onConfirm={handleDelete}
+      />
+    </div>
+  )
+}

--- a/frontend/src/routes/purchases.index.tsx
+++ b/frontend/src/routes/purchases.index.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react"
+import { createRoute } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
+import { usePageTitle } from "@/hooks/use-page-title"
+import { toast } from "sonner"
+import { Plus } from "lucide-react"
+import { rootRoute } from "./__root"
+import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from "@/hooks/use-categories"
+import { getPurchaseSummary } from "@/lib/purchase-repository"
+import { useQuery } from "@tanstack/react-query"
+import type { Category, CategoryFormData } from "@/types/category"
+import { Button } from "@/components/ui/button"
+import { CategoryCard } from "@/components/category-card"
+import { CategoryDialog } from "@/components/category-dialog"
+import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
+
+export const purchasesIndexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/purchases",
+  component: PurchasesDashboardPage,
+})
+
+function PurchasesDashboardPage() {
+  const { t } = useTranslation()
+  usePageTitle(t("nav.purchases"), t("app.title"))
+  const { data: categories = [] } = useCategories("purchases")
+  const { data: summary } = useQuery({
+    queryKey: ["purchases-summary"],
+    queryFn: getPurchaseSummary,
+  })
+  const summaryByCategory = new Map(
+    (summary?.categories ?? []).map((s) => [s.id, s]),
+  )
+  const createCategory = useCreateCategory("purchases")
+  const updateCategory = useUpdateCategory("purchases")
+  const deleteCategory = useDeleteCategory("purchases")
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null)
+  const [deletingCategory, setDeletingCategory] = useState<Category | null>(null)
+
+  function handleCreate(data: CategoryFormData) {
+    createCategory.mutate(data, { onSuccess: () => toast.success(t("category.created")) })
+  }
+
+  function handleUpdate(data: CategoryFormData) {
+    if (!editingCategory) return
+    updateCategory.mutate(
+      { id: editingCategory.id, data },
+      { onSuccess: () => toast.success(t("category.updated")) },
+    )
+    setEditingCategory(null)
+  }
+
+  function handleDelete() {
+    if (!deletingCategory) return
+    deleteCategory.mutate(deletingCategory.id, {
+      onSuccess: () => toast.success(t("category.deleted")),
+    })
+    setDeletingCategory(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t("nav.purchases")}</h1>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          {t("dashboard.newCategory")}
+        </Button>
+      </div>
+
+      {categories.length === 0 ? (
+        <p className="text-muted-foreground">{t("dashboard.noCategories")}</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {categories.map((cat) => {
+            const catSummary = summaryByCategory.get(cat.id)
+            return (
+              <CategoryCard
+                key={cat.id}
+                category={cat}
+                module="purchases"
+                totalAmount={catSummary?.totalSpent ?? 0}
+                itemLabel={t("purchase.purchaseCount", { count: catSummary?.purchaseCount ?? 0 })}
+                totalLabel={t("purchase.totalSpent", {
+                  amount: `${(catSummary?.totalSpent ?? 0).toFixed(2)} ${t("common.currency")}`,
+                })}
+                onEdit={() => setEditingCategory(cat)}
+                onDelete={() => setDeletingCategory(cat)}
+              />
+            )
+          })}
+        </div>
+      )}
+
+      <CategoryDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleCreate}
+      />
+
+      <CategoryDialog
+        open={!!editingCategory}
+        onOpenChange={(open) => { if (!open) setEditingCategory(null) }}
+        category={editingCategory}
+        onSubmit={handleUpdate}
+      />
+
+      <DeleteConfirmDialog
+        open={!!deletingCategory}
+        onOpenChange={(open) => { if (!open) setDeletingCategory(null) }}
+        description={t("category.deleteConfirm", { name: deletingCategory?.nameKey ? t(deletingCategory.nameKey) : deletingCategory?.name ?? "" })}
+        onConfirm={handleDelete}
+      />
+    </div>
+  )
+}

--- a/frontend/src/routes/router.ts
+++ b/frontend/src/routes/router.ts
@@ -1,12 +1,24 @@
 import { createRouter } from "@tanstack/react-router"
 import { rootRoute } from "./__root"
 import { indexRoute } from "."
-import { categoryRoute } from "./categories.$categoryId"
+import { contractsIndexRoute } from "./contracts.index"
+import { contractsCategoryRoute } from "./contracts.categories.$categoryId"
+import { contractsUpcomingRenewalsRoute } from "./contracts.upcoming-renewals"
+import { purchasesIndexRoute } from "./purchases.index"
+import { purchasesCategoryRoute } from "./purchases.categories.$categoryId"
 import { loginRoute } from "./login"
-import { upcomingRenewalsRoute } from "./upcoming-renewals"
 import { settingsRoute } from "./settings"
 
-const routeTree = rootRoute.addChildren([indexRoute, categoryRoute, loginRoute, upcomingRenewalsRoute, settingsRoute])
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  contractsIndexRoute,
+  contractsCategoryRoute,
+  contractsUpcomingRenewalsRoute,
+  purchasesIndexRoute,
+  purchasesCategoryRoute,
+  loginRoute,
+  settingsRoute,
+])
 
 export const router = createRouter({ routeTree })
 

--- a/frontend/src/types/purchase.ts
+++ b/frontend/src/types/purchase.ts
@@ -1,0 +1,52 @@
+import { z } from "zod/v4"
+
+export const purchaseSchema = z.object({
+  id: z.string().uuid(),
+  categoryId: z.string().uuid(),
+  type: z.string().optional(),
+  itemName: z.string().min(1),
+  brand: z.string().optional(),
+  articleNumber: z.string().optional(),
+  dealer: z.string().optional(),
+  price: z.number().nonnegative().optional(),
+  purchaseDate: z.string().date().optional(),
+  descriptionUrl: z.string().url().optional().or(z.literal("")),
+  invoiceUrl: z.string().url().optional().or(z.literal("")),
+  handbookUrl: z.string().url().optional().or(z.literal("")),
+  consumables: z.string().optional(),
+  comments: z.string().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+})
+
+export type Purchase = z.infer<typeof purchaseSchema>
+
+export const purchaseFormSchema = z.object({
+  type: z.string().optional(),
+  itemName: z.string().min(1),
+  brand: z.string().optional(),
+  articleNumber: z.string().optional(),
+  dealer: z.string().optional(),
+  price: z.number().nonnegative().optional(),
+  purchaseDate: z.string().date().optional(),
+  descriptionUrl: z.string().url().optional().or(z.literal("")),
+  invoiceUrl: z.string().url().optional().or(z.literal("")),
+  handbookUrl: z.string().url().optional().or(z.literal("")),
+  consumables: z.string().optional(),
+  comments: z.string().optional(),
+})
+
+export type PurchaseFormData = z.infer<typeof purchaseFormSchema>
+
+export interface PurchaseCategorySummary {
+  id: string
+  name: string
+  purchaseCount: number
+  totalSpent: number
+}
+
+export interface PurchaseSummary {
+  totalPurchases: number
+  totalSpent: number
+  categories: PurchaseCategorySummary[]
+}


### PR DESCRIPTION
## Summary

- **Purchase Tracking module**: Full CRUD for purchases with module-scoped categories, separate DB key prefixes, migration V2, summary endpoint, and default category seeding (PC Hardware, Entertainment, Kitchen, Tools, Household)
- **Homepage at `/`**: Overview page with clickable module cards showing contract/purchase summary stats and a quick stats section, replacing the previous redirect
- **Collapsible sidebar**: Contracts, Purchases, and General sections are now collapsible with chevron toggles; Home link added at top
- **Route restructuring**: All routes moved under `/contracts/*` and `/purchases/*` prefixes with full i18n support (en + de)

## Backend changes
- Purchase model, store interface, BadgerDB implementation
- Module-scoped category keys (`u/{userId}/mod/{module}/cat/{id}`)
- DB migration V2 moves existing categories to contracts prefix
- Default categories seeded on both registration and first login (for existing users)
- All handlers, routes, and tests updated

## Frontend changes
- New components: `PurchaseDialog`, `PurchasesTable`, `purchase-fields.ts`
- Generalized `FormFieldRenderer<T>` (was contract-specific `ContractFormField`)
- Module-aware `useCategories` hook and category repository
- `use-purchases` hooks with full CRUD
- TanStack Router route tree updated with all new routes