### PR TITLE
docs: update documentation for multi-module architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Prerequisites
 
@@ -24,6 +24,38 @@ See `frontend/CLAUDE.md` and `backend/CLAUDE.md` for per-project commands.
 - `backend/` — Go API server (stdlib net/http, BadgerDB, slog, Prometheus)
 - `Dockerfile` — Multi-stage build: frontend (Bun) → backend (Go) → Alpine runtime
 - `docker-compose.yml` — Single-service deployment with named volume for DB
+
+## Architecture overview
+
+The app is a multi-module personal finance manager. Currently two modules exist:
+
+- **Contracts** — Recurring subscriptions with renewal tracking, notice periods, and email reminders
+- **Purchases** — One-time purchases with item details, dealer info, and document links
+
+Each module has its own categories stored under separate DB key prefixes. Categories are module-scoped via the API route (`/api/v1/modules/{module}/categories`), not via a field on the Category model.
+
+### DB key schema
+
+- Contract categories: `u/{userId}/mod/contracts/cat/{categoryId}`
+- Purchase categories: `u/{userId}/mod/purchases/cat/{categoryId}`
+- Contracts: `u/{userId}/con/{contractId}`
+- Contract category index: `u/{userId}/idx/cat_con/{catId}/{conId}`
+- Purchases: `u/{userId}/pur/{purchaseId}`
+- Purchase category index: `u/{userId}/idx/cat_pur/{catId}/{purId}`
+- Schema version: `_meta/schema_version` (current: 2)
+
+### Frontend routes
+
+| Route | Purpose |
+|-------|---------|
+| `/` | Homepage with overview cards for all modules |
+| `/contracts` | Contracts dashboard |
+| `/contracts/categories/$categoryId` | Contract category detail |
+| `/contracts/upcoming-renewals` | Upcoming renewals |
+| `/purchases` | Purchases dashboard |
+| `/purchases/categories/$categoryId` | Purchase category detail |
+
+Routes use TanStack Router file-based conventions with dots for nesting (e.g. `contracts.index.tsx`, `contracts.categories.$categoryId.tsx`). All routes use `rootRoute` as parent with full paths (flat structure).
 
 ## Dev workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This file provides guidance to AI coding agents when working with code in this r
 - `task build` — Build Docker image
 - `task up` / `task down` — Docker Compose up/down
 
-See `frontend/CLAUDE.md` and `backend/CLAUDE.md` for per-project commands.
+See `frontend/AGENTS.md` and `backend/AGENTS.md` for per-project commands.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Contracts
 
-A self-hosted contract management application for tracking subscriptions, renewals, and recurring expenses. Built with a Go backend and React frontend.
+A self-hosted personal finance manager for tracking contracts, subscriptions, and purchases. Built with a Go backend and React frontend.
 
 ## Features
 
+- **Modular design** — Separate modules for contracts and purchases, each with independent categories and dashboards
 - **Contract tracking** — Store contract details including dates, pricing, notice periods, and renewal terms
-- **Category organization** — Group contracts by category (insurance, telecom, etc.)
-- **Renewal monitoring** — Dashboard showing upcoming renewals with color-coded urgency indicators
+- **Purchase tracking** — Track one-time purchases with item details, pricing, dealer info, and document links
+- **Category organization** — Per-module categories (e.g. insurance/telecom for contracts, PC hardware/tools for purchases)
+- **Homepage overview** — Dashboard at `/` with summary cards and stats across all modules
+- **Renewal monitoring** — Upcoming renewals with color-coded urgency indicators
 - **Email reminders** — Configurable SMTP-based reminder emails for approaching renewals
 - **Batch import** — Import contracts from JSON via file upload or paste
 - **Multi-user** — JWT authentication with per-user data isolation
@@ -64,16 +67,20 @@ All endpoints under `/api/v1/`. Auth endpoints are public; everything else requi
 |--------|------|-------------|
 | POST | `/auth/register` | Register user |
 | POST | `/auth/login` | Login (returns JWT) |
-| GET/POST | `/categories` | List / create categories |
-| GET/PUT/DELETE | `/categories/{id}` | Category CRUD |
+| GET/POST | `/modules/{module}/categories` | List / create categories (module: `contracts` or `purchases`) |
+| GET/PUT/DELETE | `/modules/{module}/categories/{id}` | Category CRUD (cascade deletes items) |
 | GET/POST | `/categories/{id}/contracts` | Contracts in category |
 | GET | `/contracts` | List all contracts |
 | GET/PUT/DELETE | `/contracts/{id}` | Contract CRUD |
 | GET | `/contracts/upcoming-renewals` | Renewals by date |
 | POST | `/contracts/import` | Batch JSON import |
+| GET/POST | `/categories/{id}/purchases` | Purchases in category |
+| GET | `/purchases` | List all purchases |
+| GET/PUT/DELETE | `/purchases/{id}` | Purchase CRUD |
+| GET | `/purchases/summary` | Purchase spending stats |
 | GET/PUT | `/settings` | Renewal preferences |
 | PUT | `/settings/password` | Change password |
-| GET | `/summary` | Dashboard stats |
+| GET | `/summary` | Contract dashboard stats |
 
 Health (`/healthz`), readiness (`/readyz`), and Prometheus metrics (`/metrics`) are available at the root.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Dockerfile         Multi-stage build (Bun → Go → Alpine)
 docker-compose.yml Single-service deployment with named volume
 ```
 
-See `frontend/CLAUDE.md` and `backend/CLAUDE.md` for per-project details.
+See `frontend/AGENTS.md` and `backend/AGENTS.md` for per-project details.
 
 ## API
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Prerequisites
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -62,13 +62,18 @@ All endpoints under `/api/v1/`. JSON request/response with camelCase field names
 - `GET|POST /api/v1/modules/{module}/categories` — List/create categories (module: `contracts` or `purchases`)
 - `GET|PUT|DELETE /api/v1/modules/{module}/categories/{id}` — Get/update/delete category (delete cascades to module items)
 - `GET|POST /api/v1/categories/{id}/contracts` — List/create contracts in category
+- `GET /api/v1/contracts` — List all contracts
 - `GET|PUT|DELETE /api/v1/contracts/{id}` — Get/update/delete contract
 - `GET /api/v1/contracts/upcoming-renewals` — Upcoming renewals
 - `POST /api/v1/contracts/import` — Batch JSON import
 - `GET /api/v1/summary` — Contract dashboard stats
 - `GET|POST /api/v1/categories/{id}/purchases` — List/create purchases in category
+- `GET /api/v1/purchases` — List all purchases
 - `GET|PUT|DELETE /api/v1/purchases/{id}` — Get/update/delete purchase
 - `GET /api/v1/purchases/summary` — Purchase spending stats
+- `GET /api/v1/settings` — Get renewal preferences
+- `PUT /api/v1/settings` — Update renewal preferences
+- `PUT /api/v1/settings/password` — Change password
 - `GET /healthz` — Liveness probe
 - `GET /readyz` — Readiness probe (checks DB)
 - `GET /metrics` — Prometheus metrics

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Commands
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,20 +14,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 React 19 + TypeScript SPA built with Vite. No SSR — this is a CRUD/business app behind auth.
 
-**Routing:** TanStack Router with type-safe route definitions in `src/routes/`. The router is created in `router.ts`, root layout in `__root.tsx`. Register the router type via the `Register` interface in `router.ts`.
+**Routing:** TanStack Router with type-safe route definitions in `src/routes/`. The router is created in `router.ts`, root layout in `__root.tsx`. Register the router type via the `Register` interface in `router.ts`. Routes use file-based conventions with dots for nesting (e.g. `contracts.index.tsx`, `contracts.categories.$categoryId.tsx`). All routes use `rootRoute` as parent with full paths (flat structure, no nested layout routes).
 
-**Data fetching:** TanStack Query. `QueryClientProvider` wraps the app in `App.tsx`.
+**Data fetching:** TanStack Query. `QueryClientProvider` wraps the app in `App.tsx`. Hooks in `src/hooks/` wrap query/mutation logic per module (contracts, purchases, categories).
 
-**Forms:** React Hook Form + Zod for validation via `@hookform/resolvers`.
+**Forms:** React Hook Form + Zod for validation via `@hookform/resolvers`. Field configs in `src/config/` drive both form and table rendering via `FormFieldRenderer`.
 
 **Styling:** Tailwind CSS v4 with the Vite plugin. shadcn/ui for pre-built components (config in `components.json`, components go in `src/components/ui/`). Use the `cn()` helper from `@/lib/utils` for conditional classNames.
 
 **Path alias:** `@/` maps to `src/` (configured in both tsconfig and vite.config).
 
+**i18n:** `react-i18next` with locale files in `src/i18n/locales/` (en.json, de.json).
+
 ## Key directories
 
-- `src/routes/` — Route definitions (pages)
+- `src/routes/` — Route definitions (pages): homepage, contracts/*, purchases/*
 - `src/components/` — React components; `ui/` subdirectory for shadcn/ui
-- `src/lib/` — Utilities, API client
-- `src/hooks/` — Custom React hooks
-- `src/types/` — Shared TypeScript types
+- `src/lib/` — Utilities, API client, per-module repositories (category, contract, purchase)
+- `src/hooks/` — Custom React hooks (use-categories, use-contracts, use-purchases)
+- `src/types/` — Shared TypeScript types (contract, purchase, category, summary)
+- `src/config/` — Field configuration for forms/tables (contract-fields, purchase-fields)
+- `src/i18n/` — Internationalization setup and locale files

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Contracts — Frontend
 
-React SPA for the Contracts application.
+React SPA for the Contracts application — a multi-module personal finance manager.
 
 ## Tech Stack
 
@@ -9,6 +9,7 @@ React SPA for the Contracts application.
 - **TanStack Router** for type-safe routing
 - **TanStack Query** for server state / data fetching
 - **React Hook Form** + **Zod** for forms and validation
+- **react-i18next** for internationalization (en/de)
 
 ## Getting Started
 
@@ -43,11 +44,13 @@ Browse available components at [ui.shadcn.com](https://ui.shadcn.com).
 
 ```
 src/
-  routes/        Route definitions (pages)
+  routes/        Route definitions (homepage, contracts/*, purchases/*)
   components/    React components (ui/ for shadcn)
-  lib/           Utilities, API client
-  hooks/         Custom React hooks
+  lib/           Utilities, API client, per-module repositories
+  hooks/         Custom React hooks (categories, contracts, purchases)
   types/         Shared TypeScript types
+  config/        Field configurations for forms/tables
+  i18n/          Internationalization (en.json, de.json)
 ```
 
 The `@/` import alias maps to `src/`.


### PR DESCRIPTION
## Summary

- Update all documentation files (README.md, AGENTS.md, backend/AGENTS.md, frontend/AGENTS.md, frontend/README.md) to reflect the purchase tracking module, module-scoped categories, updated API routes, DB key schema, and new frontend routes
- Rename `backend/CLAUDE.md` and `frontend/CLAUDE.md` to `AGENTS.md` and update all cross-references