### PR TITLE
feat: clean up sidebar navigation and embed upcoming renewals

### DIFF
--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -8,10 +8,14 @@ import { ChevronRight, Home } from "lucide-react"
 
 function SidebarSection({
   title,
+  to,
+  isActive,
   defaultOpen = true,
   children,
 }: {
   title: string
+  to?: string
+  isActive?: boolean
   defaultOpen?: boolean
   children: React.ReactNode
 }) {
@@ -19,10 +23,26 @@ function SidebarSection({
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger className="flex w-full items-center gap-1 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors">
-        <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} />
-        {title}
-      </CollapsibleTrigger>
+      <div className="flex items-center">
+        <CollapsibleTrigger className="flex items-center px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} />
+        </CollapsibleTrigger>
+        {to ? (
+          <Link
+            to={to}
+            className={cn(
+              "flex-1 py-1.5 text-xs font-semibold uppercase tracking-wider transition-colors hover:text-foreground",
+              isActive ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {title}
+          </Link>
+        ) : (
+          <CollapsibleTrigger className="flex-1 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors">
+            {title}
+          </CollapsibleTrigger>
+        )}
+      </div>
       <CollapsibleContent>
         <div className="flex flex-col gap-1">
           {children}
@@ -54,29 +74,13 @@ export function Sidebar() {
 
         <div className="my-2" />
 
-        <SidebarSection title={t("nav.contracts")}>
-          <Link
-            to="/contracts"
-            className={cn(
-              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-              matchRoute({ to: "/contracts" }) && "bg-accent",
-            )}
-          >
-            {t("nav.dashboard")}
-          </Link>
-
-          <Link
-            to="/contracts/upcoming-renewals"
-            className={cn(
-              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-              matchRoute({ to: "/contracts/upcoming-renewals" }) && "bg-accent",
-            )}
-          >
-            {t("nav.upcomingRenewals")}
-          </Link>
-
+        <SidebarSection
+          title={t("nav.contracts")}
+          to="/contracts"
+          isActive={!!matchRoute({ to: "/contracts", fuzzy: true })}
+        >
           {contractCategories.map((category) => {
-            const isActive = matchRoute({
+            const active = matchRoute({
               to: "/contracts/categories/$categoryId",
               params: { categoryId: category.id },
             })
@@ -86,8 +90,8 @@ export function Sidebar() {
                 to="/contracts/categories/$categoryId"
                 params={{ categoryId: category.id }}
                 className={cn(
-                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent pl-6",
-                  isActive && "bg-accent font-medium",
+                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent",
+                  active && "bg-accent font-medium",
                 )}
               >
                 {category.nameKey ? t(category.nameKey) : category.name}
@@ -96,19 +100,13 @@ export function Sidebar() {
           })}
         </SidebarSection>
 
-        <SidebarSection title={t("nav.purchases")}>
-          <Link
-            to="/purchases"
-            className={cn(
-              "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
-              matchRoute({ to: "/purchases" }) && "bg-accent",
-            )}
-          >
-            {t("nav.dashboard")}
-          </Link>
-
+        <SidebarSection
+          title={t("nav.purchases")}
+          to="/purchases"
+          isActive={!!matchRoute({ to: "/purchases", fuzzy: true })}
+        >
           {purchaseCategories.map((category) => {
-            const isActive = matchRoute({
+            const active = matchRoute({
               to: "/purchases/categories/$categoryId",
               params: { categoryId: category.id },
             })
@@ -118,8 +116,8 @@ export function Sidebar() {
                 to="/purchases/categories/$categoryId"
                 params={{ categoryId: category.id }}
                 className={cn(
-                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent pl-6",
-                  isActive && "bg-accent font-medium",
+                  "rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent",
+                  active && "bg-accent font-medium",
                 )}
               >
                 {category.nameKey ? t(category.nameKey) : category.name}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -24,7 +24,10 @@ function SidebarSection({
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <div className="flex items-center">
-        <CollapsibleTrigger className="flex items-center px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors">
+        <CollapsibleTrigger
+          className="flex items-center px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={`Toggle ${title} section`}
+        >
           <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} />
         </CollapsibleTrigger>
         {to ? (

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -180,6 +180,7 @@
     "currency": "€",
     "months": "Monate",
     "perMonth": "/ Mon.",
-    "perYear": "/ Jahr"
+    "perYear": "/ Jahr",
+    "viewAll": "Alle anzeigen"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -180,6 +180,7 @@
     "currency": "€",
     "months": "months",
     "perMonth": "/ mo",
-    "perYear": "/ yr"
+    "perYear": "/ yr",
+    "viewAll": "View all"
   }
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,16 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { differenceInDays } from "date-fns"
+import type { Contract } from "@/types/contract"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function getRenewalRowClass(c: Contract): string | undefined {
+  if (!c.cancellationDate) return undefined
+  const days = differenceInDays(new Date(c.cancellationDate), new Date())
+  if (days <= 30) return "bg-destructive/10 hover:bg-destructive/20"
+  if (days <= 90) return "bg-yellow-500/10 hover:bg-yellow-500/20"
+  return "text-muted-foreground opacity-75"
 }

--- a/frontend/src/routes/contracts.index.tsx
+++ b/frontend/src/routes/contracts.index.tsx
@@ -10,7 +10,6 @@ import { useUpcomingRenewals } from "@/hooks/use-contracts"
 import { useSettings } from "@/hooks/use-settings"
 import { getSummary, updateContract, deleteContract } from "@/lib/contract-repository"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { differenceInDays } from "date-fns"
 import type { Category, CategoryFormData } from "@/types/category"
 import type { Contract, ContractFormData } from "@/types/contract"
 import { Button } from "@/components/ui/button"
@@ -20,6 +19,7 @@ import { ContractsTable } from "@/components/contracts-table"
 import { ContractDialog } from "@/components/contract-dialog"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
 import { ImportDialog } from "@/components/import-dialog"
+import { getRenewalRowClass } from "@/lib/utils"
 
 export const contractsIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -58,6 +58,7 @@ function ContractsDashboardPage() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contracts"] })
       qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      qc.invalidateQueries({ queryKey: ["summary"] })
       toast.success(t("contract.updated"))
       setEditingContract(null)
     },
@@ -68,6 +69,7 @@ function ContractsDashboardPage() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contracts"] })
       qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      qc.invalidateQueries({ queryKey: ["summary"] })
       toast.success(t("contract.deleted"))
       setDeletingContract(null)
     },
@@ -102,14 +104,6 @@ function ContractsDashboardPage() {
   function handleContractDelete() {
     if (!deletingContract) return
     deleteContractMutation.mutate({ id: deletingContract.id })
-  }
-
-  function getRenewalRowClass(c: Contract) {
-    if (!c.cancellationDate) return undefined
-    const days = differenceInDays(new Date(c.cancellationDate), new Date())
-    if (days <= 30) return "bg-destructive/10 hover:bg-destructive/20"
-    if (days <= 90) return "bg-yellow-500/10 hover:bg-yellow-500/20"
-    return "text-muted-foreground opacity-75"
   }
 
   return (

--- a/frontend/src/routes/contracts.index.tsx
+++ b/frontend/src/routes/contracts.index.tsx
@@ -1,17 +1,23 @@
 import { useState } from "react"
-import { createRoute } from "@tanstack/react-router"
+import { createRoute, Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { usePageTitle } from "@/hooks/use-page-title"
 import { toast } from "sonner"
 import { Plus, Upload } from "lucide-react"
 import { rootRoute } from "./__root"
 import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from "@/hooks/use-categories"
-import { getSummary } from "@/lib/contract-repository"
-import { useQuery } from "@tanstack/react-query"
+import { useUpcomingRenewals } from "@/hooks/use-contracts"
+import { useSettings } from "@/hooks/use-settings"
+import { getSummary, updateContract, deleteContract } from "@/lib/contract-repository"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { differenceInDays } from "date-fns"
 import type { Category, CategoryFormData } from "@/types/category"
+import type { Contract, ContractFormData } from "@/types/contract"
 import { Button } from "@/components/ui/button"
 import { CategoryCard } from "@/components/category-card"
 import { CategoryDialog } from "@/components/category-dialog"
+import { ContractsTable } from "@/components/contracts-table"
+import { ContractDialog } from "@/components/contract-dialog"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
 import { ImportDialog } from "@/components/import-dialog"
 
@@ -36,10 +42,36 @@ function ContractsDashboardPage() {
   const updateCategory = useUpdateCategory("contracts")
   const deleteCategory = useDeleteCategory("contracts")
 
+  const { data: settings } = useSettings()
+  const { data: upcomingContracts = [] } = useUpcomingRenewals(settings?.renewalDays)
+  const qc = useQueryClient()
+
   const [dialogOpen, setDialogOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [editingCategory, setEditingCategory] = useState<Category | null>(null)
   const [deletingCategory, setDeletingCategory] = useState<Category | null>(null)
+  const [editingContract, setEditingContract] = useState<Contract | null>(null)
+  const [deletingContract, setDeletingContract] = useState<Contract | null>(null)
+
+  const updateContractMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ContractFormData }) => updateContract(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["contracts"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      toast.success(t("contract.updated"))
+      setEditingContract(null)
+    },
+  })
+
+  const deleteContractMutation = useMutation({
+    mutationFn: ({ id }: { id: string }) => deleteContract(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["contracts"] })
+      qc.invalidateQueries({ queryKey: ["categories", "contracts"] })
+      toast.success(t("contract.deleted"))
+      setDeletingContract(null)
+    },
+  })
 
   function handleCreate(data: CategoryFormData) {
     createCategory.mutate(data, { onSuccess: () => toast.success(t("category.created")) })
@@ -60,6 +92,24 @@ function ContractsDashboardPage() {
       onSuccess: () => toast.success(t("category.deleted")),
     })
     setDeletingCategory(null)
+  }
+
+  function handleContractUpdate(data: ContractFormData) {
+    if (!editingContract) return
+    updateContractMutation.mutate({ id: editingContract.id, data })
+  }
+
+  function handleContractDelete() {
+    if (!deletingContract) return
+    deleteContractMutation.mutate({ id: deletingContract.id })
+  }
+
+  function getRenewalRowClass(c: Contract) {
+    if (!c.cancellationDate) return undefined
+    const days = differenceInDays(new Date(c.cancellationDate), new Date())
+    if (days <= 30) return "bg-destructive/10 hover:bg-destructive/20"
+    if (days <= 90) return "bg-yellow-500/10 hover:bg-yellow-500/20"
+    return "text-muted-foreground opacity-75"
   }
 
   return (
@@ -106,6 +156,26 @@ function ContractsDashboardPage() {
         </div>
       )}
 
+      {upcomingContracts.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t("nav.upcomingRenewals")}</h2>
+            <Link
+              to="/contracts/upcoming-renewals"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t("common.viewAll")}
+            </Link>
+          </div>
+          <ContractsTable
+            contracts={upcomingContracts.slice(0, 5)}
+            onEdit={(c) => setEditingContract(c)}
+            onDelete={(c) => setDeletingContract(c)}
+            getRowClassName={getRenewalRowClass}
+          />
+        </div>
+      )}
+
       <CategoryDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
@@ -126,6 +196,20 @@ function ContractsDashboardPage() {
         onOpenChange={(open) => { if (!open) setDeletingCategory(null) }}
         description={t("category.deleteConfirm", { name: deletingCategory?.nameKey ? t(deletingCategory.nameKey) : deletingCategory?.name ?? "" })}
         onConfirm={handleDelete}
+      />
+
+      <ContractDialog
+        open={!!editingContract}
+        onOpenChange={(open) => { if (!open) setEditingContract(null) }}
+        contract={editingContract}
+        onSubmit={handleContractUpdate}
+      />
+
+      <DeleteConfirmDialog
+        open={!!deletingContract}
+        onOpenChange={(open) => { if (!open) setDeletingContract(null) }}
+        description={t("contract.deleteConfirm", { name: deletingContract?.name ?? "" })}
+        onConfirm={handleContractDelete}
       />
     </div>
   )

--- a/frontend/src/routes/contracts.upcoming-renewals.tsx
+++ b/frontend/src/routes/contracts.upcoming-renewals.tsx
@@ -8,11 +8,11 @@ import { useUpcomingRenewals } from "@/hooks/use-contracts"
 import { useSettings } from "@/hooks/use-settings"
 import { updateContract, deleteContract } from "@/lib/contract-repository"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { differenceInDays } from "date-fns"
 import type { Contract, ContractFormData } from "@/types/contract"
 import { ContractsTable } from "@/components/contracts-table"
 import { ContractDialog } from "@/components/contract-dialog"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
+import { getRenewalRowClass } from "@/lib/utils"
 
 export const contractsUpcomingRenewalsRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -60,14 +60,6 @@ function UpcomingRenewalsPage() {
     deleteMutation.mutate({ id: deletingContract.id })
   }
 
-  function getRowClass(c: Contract) {
-    if (!c.cancellationDate) return undefined
-    const days = differenceInDays(new Date(c.cancellationDate), new Date())
-    if (days <= 30) return "bg-destructive/10 hover:bg-destructive/20"
-    if (days <= 90) return "bg-yellow-500/10 hover:bg-yellow-500/20"
-    return "text-muted-foreground opacity-75"
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
@@ -78,7 +70,7 @@ function UpcomingRenewalsPage() {
         contracts={contracts}
         onEdit={(c) => setEditingContract(c)}
         onDelete={(c) => setDeletingContract(c)}
-        getRowClassName={getRowClass}
+        getRowClassName={getRenewalRowClass}
       />
 
       <ContractDialog


### PR DESCRIPTION
## Summary

- **Sidebar section headers now serve as navigation links** — clicking the title text navigates to the module dashboard (`/contracts` or `/purchases`), while the chevron icon independently toggles section collapse/expand
- **Removed redundant "Dashboard" sub-links** from both Contracts and Purchases sidebar sections, since the section title now handles navigation
- **Removed "Upcoming Renewals" from sidebar** — instead, a preview of the first 5 upcoming renewals is embedded directly on the contracts dashboard with a "View all" link to the full page
- **Flattened category indentation** — categories now sit at the same level as other sidebar items instead of being indented as sub-sub elements

## Changes

| File | What |
|------|------|
| `sidebar.tsx` | Refactored `SidebarSection` with split click zones (chevron vs title link), removed Dashboard/Upcoming Renewals links, removed `pl-6` from categories |
| `contracts.index.tsx` | Added upcoming renewals section with `ContractsTable` (limited to 5 items), edit/delete contract support, "View all" link |
| `en.json` / `de.json` | Added `common.viewAll` key |

The standalone `/contracts/upcoming-renewals` route is unchanged and remains deep-linkable.