### PR TITLE
fix: align local checks with CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ After every change, check whether `AGENTS.md` (root, `backend/`, `frontend/`) an
 ## Commands (from repo root)
 
 - `task dev` — Start backend (Air) + frontend (Vite) concurrently
+- `task ci` — Run the local backend + frontend checks that must pass before committing
+- `task ci:backend` — Run backend test + lint checks
+- `task ci:frontend` — Run frontend lint + build checks
 - `task build` — Build Docker image
 - `task up` / `task down` — Docker Compose up/down
 
@@ -79,3 +82,5 @@ All development must be done on feature branches. Never commit directly to `main
 ## Dev workflow
 
 `task dev` from root starts both services. Vite dev server (port 5173) proxies `/api/*`, `/healthz`, `/readyz`, `/metrics` to the Go backend (port 8080). Open http://localhost:5173 in the browser.
+
+Before committing, run `task ci` from the repo root. If you only changed one side, you may additionally run the narrower `task ci:backend` or `task ci:frontend` while iterating, but the full root `task ci` is the required pre-commit check.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,26 @@
 version: "3"
 
 tasks:
+  ci:
+    desc: Run the same local checks expected by CI
+    deps:
+      - ci:backend
+      - ci:frontend
+
+  ci:backend:
+    desc: Run backend test and lint checks
+    dir: backend
+    cmds:
+      - task test
+      - task lint
+
+  ci:frontend:
+    desc: Run frontend lint and build checks
+    dir: frontend
+    cmds:
+      - bun run lint
+      - bun run build
+
   dev:
     desc: Run backend and frontend concurrently
     deps:

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -18,7 +18,7 @@ After every change, check whether `AGENTS.md` (root, `backend/`, `frontend/`) an
 - `task dev` — Start with Air (live reload), sets `CORS_ORIGIN` for frontend dev server
 - `task build` — Build the binary
 - `task test` — Run tests
-- `task lint` — Run golangci-lint
+- `task lint` — Run golangci-lint (use a recent binary compatible with the repo Go version)
 
 ## Architecture
 

--- a/backend/internal/store/badger_ledger.go
+++ b/backend/internal/store/badger_ledger.go
@@ -62,10 +62,6 @@ func idxLedAccTxnKey(userID string, accountID uuid.UUID, bookingDate string, txn
 	return []byte(fmt.Sprintf("u/%s/idx/led_acc_txn/%s/%s/%s", userID, accountID, bookingDate, txnID))
 }
 
-func idxLedAccTxnPrefix(userID string, accountID uuid.UUID) []byte {
-	return []byte(fmt.Sprintf("u/%s/idx/led_acc_txn/%s/", userID, accountID))
-}
-
 func idxLedTxnFPKey(userID string, fingerprint string) []byte {
 	return []byte(fmt.Sprintf("u/%s/idx/led_txn_fp/%s", userID, fingerprint))
 }
@@ -568,10 +564,6 @@ func syncLedgerReferences(txn *badger.Txn, userID string, transactionID uuid.UUI
 		}
 	}
 	return nil
-}
-
-func removeLedgerTransactionLinksFromTargets(txn *badger.Txn, userID string, transaction model.LedgerTransaction) error {
-	return syncLedgerReferences(txn, userID, transaction.ID, transaction.References, nil)
 }
 
 func removeLedgerTransactionLinks(txn *badger.Txn, userID string, transactionIDs []uuid.UUID, referenceType string, targetID uuid.UUID) error {


### PR DESCRIPTION
## Summary
- remove dead backend helpers that failed golangci-lint in CI
- add explicit root-level CI tasks for backend and frontend checks
- document the required pre-commit check flow in AGENTS guidance