### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md at all levels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Claude Code only reads CLAUDE.md, not AGENTS.md
- Add relative symlinks `CLAUDE.md -> AGENTS.md` at repo root, `backend/`, and `frontend/` so the shared agent instructions are picked up by Claude Code without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)