### PR TITLE
chore: rename project from Contracts to Kontor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ See `frontend/AGENTS.md` and `backend/AGENTS.md` for per-project commands.
 
 ## Architecture overview
 
-The app is a multi-module personal finance manager. Currently four modules exist:
+The app ("Kontor") is a multi-module personal finance manager. Currently four modules exist:
 
 - **Contracts** — Recurring subscriptions with renewal tracking, notice periods, and email reminders
 - **Purchases** — One-time purchases with item details, dealer info, and document links

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ .
 RUN CGO_ENABLED=0 go build \
-    -ldflags "-X github.com/tobi/contracts/backend/internal/version.Version=${VERSION} -X github.com/tobi/contracts/backend/internal/version.Commit=${COMMIT} -X github.com/tobi/contracts/backend/internal/version.BuildDate=${BUILD_DATE}" \
+    -ldflags "-X github.com/reusing-code/kontor/backend/internal/version.Version=${VERSION} -X github.com/reusing-code/kontor/backend/internal/version.Commit=${COMMIT} -X github.com/reusing-code/kontor/backend/internal/version.BuildDate=${BUILD_DATE}" \
     -o server ./cmd/server
 
 FROM alpine:3.21

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Contracts
+# Kontor
 
 A self-hosted personal finance manager for tracking contracts, subscriptions, purchases, vehicle costs, and ledger transactions. Built with a Go backend and React frontend.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,7 @@ tasks:
   build:
     desc: Build Docker image
     cmds:
-      - docker build -t contracts .
+      - docker build -t kontor .
 
   up:
     desc: Start with docker compose

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -9,9 +9,9 @@ vars:
   BUILD_DATE:
     sh: date -u +%Y-%m-%d
   LDFLAGS: >-
-    -X github.com/tobi/contracts/backend/internal/version.Version={{.VERSION}}
-    -X github.com/tobi/contracts/backend/internal/version.Commit={{.COMMIT}}
-    -X github.com/tobi/contracts/backend/internal/version.BuildDate={{.BUILD_DATE}}
+    -X github.com/reusing-code/kontor/backend/internal/version.Version={{.VERSION}}
+    -X github.com/reusing-code/kontor/backend/internal/version.Commit={{.COMMIT}}
+    -X github.com/reusing-code/kontor/backend/internal/version.BuildDate={{.BUILD_DATE}}
 
 tasks:
   dev:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/tobi/contracts/backend/internal/config"
-	"github.com/tobi/contracts/backend/internal/server"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/config"
+	"github.com/reusing-code/kontor/backend/internal/server"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 func main() {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/tobi/contracts/backend
+module github.com/reusing-code/kontor/backend
 
 go 1.26.1
 

--- a/backend/internal/email/client.go
+++ b/backend/internal/email/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/config"
+	"github.com/reusing-code/kontor/backend/internal/config"
 )
 
 type Client struct {

--- a/backend/internal/email/client_test.go
+++ b/backend/internal/email/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/config"
+	"github.com/reusing-code/kontor/backend/internal/config"
 )
 
 // mockSMTPServer starts a simple TCP listener that mocks basic SMTP responses

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/backend/internal/handler/category.go
+++ b/backend/internal/handler/category.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListCategories(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/contract.go
+++ b/backend/internal/handler/contract.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListContracts(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/contract_view.go
+++ b/backend/internal/handler/contract_view.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 type contractView struct {

--- a/backend/internal/handler/cost_entry.go
+++ b/backend/internal/handler/cost_entry.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListCostEntries(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/export.go
+++ b/backend/internal/handler/export.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/version"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/version"
 )
 
 type exportPayload struct {
@@ -103,7 +103,7 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filename := fmt.Sprintf("contracts-export-%s.json", payload.ExportedAt.Format("20060102-150405"))
+	filename := fmt.Sprintf("kontor-export-%s.json", payload.ExportedAt.Format("20060102-150405"))
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 	h.writeJSON(w, http.StatusOK, payload)
 }

--- a/backend/internal/handler/export_test.go
+++ b/backend/internal/handler/export_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func newExportMux(h *Handler) http.Handler {

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/cryptoutil"
-	"github.com/tobi/contracts/backend/internal/email"
-	"github.com/tobi/contracts/backend/internal/ledgeremail"
-	"github.com/tobi/contracts/backend/internal/ledgerimport"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/cryptoutil"
+	"github.com/reusing-code/kontor/backend/internal/email"
+	"github.com/reusing-code/kontor/backend/internal/ledgeremail"
+	"github.com/reusing-code/kontor/backend/internal/ledgerimport"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 type Handler struct {

--- a/backend/internal/handler/handler_test.go
+++ b/backend/internal/handler/handler_test.go
@@ -13,9 +13,9 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 func (h *Handler) Healthz(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/handler/import.go
+++ b/backend/internal/handler/import.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 type contractImportEntry struct {

--- a/backend/internal/handler/ledger_category.go
+++ b/backend/internal/handler/ledger_category.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 func (h *Handler) ListLedgerCategories(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/ledger_defaults.go
+++ b/backend/internal/handler/ledger_defaults.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 	"go.yaml.in/yaml/v2"
 )
 

--- a/backend/internal/handler/ledger_email.go
+++ b/backend/internal/handler/ledger_email.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/cryptoutil"
-	"github.com/tobi/contracts/backend/internal/ledgeremail"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/cryptoutil"
+	"github.com/reusing-code/kontor/backend/internal/ledgeremail"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListLedgerEmailAccounts(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/ledger_import.go
+++ b/backend/internal/handler/ledger_import.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/tobi/contracts/backend/internal/ledgerimport"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/ledgerimport"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 func (h *Handler) LedgerImportPreview(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/purchase.go
+++ b/backend/internal/handler/purchase.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListPurchases(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/purchase_summary.go
+++ b/backend/internal/handler/purchase_summary.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
 )
 
 type purchaseCategorySummary struct {

--- a/backend/internal/handler/restore.go
+++ b/backend/internal/handler/restore.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 type restoreResult struct {

--- a/backend/internal/handler/restore_test.go
+++ b/backend/internal/handler/restore_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func newExportRestoreMux(h *Handler) http.Handler {

--- a/backend/internal/handler/settings.go
+++ b/backend/internal/handler/settings.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"net/http"
 
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/backend/internal/handler/summary.go
+++ b/backend/internal/handler/summary.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
 )
 
 type categorySummary struct {

--- a/backend/internal/handler/vehicle.go
+++ b/backend/internal/handler/vehicle.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) ListVehicles(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/vehicle_summary.go
+++ b/backend/internal/handler/vehicle_summary.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func (h *Handler) VehicleSummary(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/ledgercategorization/matcher.go
+++ b/backend/internal/ledgercategorization/matcher.go
@@ -3,7 +3,7 @@ package ledgercategorization
 import (
 	"strings"
 
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 type MatchResult struct {

--- a/backend/internal/ledgeremail/importers.go
+++ b/backend/internal/ledgeremail/importers.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 var (

--- a/backend/internal/ledgeremail/scheduler.go
+++ b/backend/internal/ledgeremail/scheduler.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/cryptoutil"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/cryptoutil"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 const accountScanTimeout = 10 * time.Minute

--- a/backend/internal/ledgeremail/scheduler_test.go
+++ b/backend/internal/ledgeremail/scheduler_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func TestAccountDue(t *testing.T) {

--- a/backend/internal/ledgeremail/service.go
+++ b/backend/internal/ledgeremail/service.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 	"golang.org/x/net/html/charset"
 )
 

--- a/backend/internal/ledgerimport/service.go
+++ b/backend/internal/ledgerimport/service.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/ledgercategorization"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/ledgercategorization"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 type Service struct {

--- a/backend/internal/ledgerimport/service_test.go
+++ b/backend/internal/ledgerimport/service_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 type mockStore struct {

--- a/backend/internal/reminder/scheduler.go
+++ b/backend/internal/reminder/scheduler.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tobi/contracts/backend/internal/email"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/email"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 var frequencyDurations = map[string]time.Duration{

--- a/backend/internal/reminder/scheduler_test.go
+++ b/backend/internal/reminder/scheduler_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 type mockStore struct {

--- a/backend/internal/server/integration_test.go
+++ b/backend/internal/server/integration_test.go
@@ -9,10 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/tobi/contracts/backend/internal/handler"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/handler"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store"
 )
 
 var testJWTSecret = []byte("integration-test-secret")

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -13,15 +13,15 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/tobi/contracts/backend/internal/config"
-	"github.com/tobi/contracts/backend/internal/cryptoutil"
-	"github.com/tobi/contracts/backend/internal/email"
-	"github.com/tobi/contracts/backend/internal/handler"
-	"github.com/tobi/contracts/backend/internal/ledgeremail"
-	"github.com/tobi/contracts/backend/internal/middleware"
-	"github.com/tobi/contracts/backend/internal/reminder"
-	"github.com/tobi/contracts/backend/internal/store"
-	"github.com/tobi/contracts/backend/internal/version"
+	"github.com/reusing-code/kontor/backend/internal/config"
+	"github.com/reusing-code/kontor/backend/internal/cryptoutil"
+	"github.com/reusing-code/kontor/backend/internal/email"
+	"github.com/reusing-code/kontor/backend/internal/handler"
+	"github.com/reusing-code/kontor/backend/internal/ledgeremail"
+	"github.com/reusing-code/kontor/backend/internal/middleware"
+	"github.com/reusing-code/kontor/backend/internal/reminder"
+	"github.com/reusing-code/kontor/backend/internal/store"
+	"github.com/reusing-code/kontor/backend/internal/version"
 )
 
 type Server struct {

--- a/backend/internal/store/badger.go
+++ b/backend/internal/store/badger.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
-	"github.com/tobi/contracts/backend/internal/store/migration"
+	"github.com/reusing-code/kontor/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/store/migration"
 )
 
 var (

--- a/backend/internal/store/badger_ledger.go
+++ b/backend/internal/store/badger_ledger.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 var (

--- a/backend/internal/store/badger_ledger_test.go
+++ b/backend/internal/store/badger_ledger_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 func TestLedgerAccount_CreateConflictOnIBAN(t *testing.T) {

--- a/backend/internal/store/badger_test.go
+++ b/backend/internal/store/badger_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 const testUser = "test-user"

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	"github.com/tobi/contracts/backend/internal/model"
+	"github.com/reusing-code/kontor/backend/internal/model"
 )
 
 type LedgerTransactionPage struct {

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
-  contracts:
-    image: ghcr.io/reusing-code/contracts:0.0 
+  kontor:
+    image: ghcr.io/reusing-code/kontor:0.0 
     ports:
       - "8080:8080"
     volumes:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Contracts — Frontend
+# Kontor — Frontend
 
-React SPA for the Contracts application — a multi-module personal finance manager covering contracts, purchases, vehicles, and ledger transactions.
+React SPA for the Kontor application — a multi-module personal finance manager covering contracts, purchases, vehicles, and ledger transactions.
 
 ## Tech Stack
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Contracts</title>
+    <title>Kontor</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "Verträge"
+    "title": "Kontor"
   },
   "home": {
     "title": "Übersicht",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "Contracts"
+    "title": "Kontor"
   },
   "home": {
     "title": "Overview",

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -85,8 +85,8 @@ function VersionIndicator() {
 
   return (
     <div className="py-1 text-center text-[11px] text-muted-foreground/60">
-      <a href="https://github.com/reusing-code/contracts" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground">
-        Contracts
+      <a href="https://github.com/reusing-code/kontor" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground">
+        Kontor
       </a>
       {" "}
       {label}

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -77,7 +77,7 @@ export function SettingsPage() {
   async function handleExport() {
     setExporting(true)
     try {
-      await download("/export", "contracts-export.json")
+      await download("/export", "kontor-export.json")
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t("settings.exportFailed"))
     } finally {


### PR DESCRIPTION
## Summary

Relaunch step 1: the app has grown from a contract tracker into a multi-module personal finance manager, so the product gets a scope-neutral name — **Kontor**. The Contracts *feature module* keeps its name (routes, DB keys, nav labels unchanged).

- **Go module path**: `github.com/tobi/contracts/backend` → `github.com/reusing-code/kontor/backend` across all imports, plus ldflags in `Dockerfile` and `backend/Taskfile.yml` (also fixes the old owner mismatch)
- **Docker/build**: compose service + image `ghcr.io/reusing-code/kontor:0.0`, `docker build -t kontor`; CI workflow unchanged (derives image from repo name, repo already renamed)
- **Branding**: browser `<title>`, i18n `app.title` (en/de both "Kontor"), footer GitHub link
- **Export filename**: `kontor-export-*.json` (backend + frontend)
- **Docs**: README headings/taglines, AGENTS.md overview

## Test plan

- [x] `task ci` green (backend tests + lint, frontend lint + build)
- [x] Repo-wide grep: no remaining `tobi/contracts`, `reusing-code/contracts`, or `contracts-export` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbB1ySLkZKfaztf3tGjy7E