### PR TITLE
fix: return empty items array for empty ledger transaction pages

### DIFF
--- a/backend/internal/modules/ledger/store.go
+++ b/backend/internal/modules/ledger/store.go
@@ -624,6 +624,9 @@ func paginateLedgerTransactions(txns []LedgerTransaction, limit int, cursor stri
 		end = len(txns)
 	}
 	page.Items = txns[start:end]
+	if page.Items == nil {
+		page.Items = []LedgerTransaction{}
+	}
 	if end < len(txns) && end > start {
 		page.NextCursor = txns[end-1].ID.String()
 	}

--- a/backend/internal/modules/ledger/store_test.go
+++ b/backend/internal/modules/ledger/store_test.go
@@ -150,6 +150,25 @@ func TestLedgerTransactionsPage_PaginatesNewestFirst(t *testing.T) {
 	}
 }
 
+func TestLedgerTransactionsFiltered_EmptyResultHasNonNilItems(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	page, err := s.ListLedgerTransactionsFiltered(ctx, "user-1", LedgerTransactionListOptions{
+		ReviewStatus: LedgerTransactionReviewNeedsReview,
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("ListLedgerTransactionsFiltered: %v", err)
+	}
+	if page.Items == nil {
+		t.Fatal("page.Items is nil, want empty slice (serializes to JSON null otherwise)")
+	}
+	if len(page.Items) != 0 {
+		t.Fatalf("page.Items len = %d, want 0", len(page.Items))
+	}
+}
+
 func TestLedgerCommitImport_RejectsDuplicateFile(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- `paginateLedgerTransactions` sliced a nil `filtered` slice when no transactions matched, so empty pages serialized as `{"items":null}`
- The ledger home card (`ledgerReviewPage?.items.length`) crashed the homepage on a fresh database — first hit after the relaunch DB wipe; the bug predates #18
- Guard against nil after slicing (matching the nil-guards in the other list functions) and add a regression test

## Test plan
- [x] `task ci:backend` (tests + lint) passes, including new `TestLedgerTransactionsFiltered_EmptyResultHasNonNilItems`
- [x] Verified live: `GET /api/v1/ledger/transactions?limit=10` on a fresh account now returns `{"items":[]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYegrp45D16haPmGpiqxvu