### PR TITLE
feat: merge inspection into service cost type, add vehicle statistics page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The app ("Kontor") is a multi-module personal finance manager. Modules are first
 
 - **Contracts** — Recurring subscriptions with renewal tracking, notice periods, and email reminders
 - **Purchases** — One-time purchases with item details, dealer info, and document links
-- **Auto** — Vehicle management with cost tracking (service, fuel, insurance, tax, inspection, tires, mileage, misc) and total cost of ownership projections
+- **Auto** — Vehicle management with cost tracking (service, fuel, insurance, tax, tires, mileage, misc) and total cost of ownership projections
 - **Ledger** — Bank account and transaction tracking with CSV import, review queue, category matching, cross references, explicit internal transfer linking between tracked accounts, and email-order enrichment from IMAP inbox scans (manual or scheduled in the background) or uploaded `.eml` messages
 
 Contracts and purchases share the item-category machinery (`backend/internal/categories`), scoped via the API route (`/api/v1/modules/{module}/categories`). The Auto module uses its own vehicle/cost key structure instead of categories. The Ledger module has its own hierarchical category type. Cross-module links between ledger transactions and contract/purchase/vehicle items go through the link registry (`backend/internal/storage/link`) so modules never import each other.
@@ -71,7 +71,8 @@ Migrations are per module: each module supplies its own `Migrations()` list, app
 | `/purchases` | Purchases dashboard |
 | `/purchases/categories/$categoryId` | Purchase category detail |
 | `/auto` | Auto / vehicles dashboard |
-| `/auto/vehicles/$vehicleId` | Vehicle detail with cost entries and summary |
+| `/auto/vehicles/$vehicleId` | Vehicle detail with cost entries and headline stats |
+| `/auto/vehicles/$vehicleId/statistics` | Vehicle statistics with charts, yearly breakdowns, and projection |
 | `/ledger` | Ledger dashboard with accounts, imports, categories, and review queue |
 | `/ledger/accounts/$accountId` | Ledger account detail with transactions |
 | `/ledger/categories` | Ledger category tree manager |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A self-hosted personal finance manager for tracking contracts, subscriptions, pu
 - **Modular design** — First-class modules (contracts, purchases, auto, ledger) with independent dashboards; enable or disable modules per account (data is kept while disabled)
 - **Contract tracking** — Store contract details including dates, pricing, notice periods, and renewal terms
 - **Purchase tracking** — Track one-time purchases with item details, pricing, dealer info, and document links
-- **Vehicle cost tracking** — Manage vehicles with cost entries (service, fuel, insurance, tax, inspection, tires, mileage, misc) and total cost of ownership projections
+- **Vehicle cost tracking** — Manage vehicles with cost entries (service, fuel, insurance, tax, tires, mileage, misc), a per-vehicle statistics page with charts, and total cost of ownership projections
 - **Ledger module** — Import bank CSVs into tracked accounts, review transactions, manage categories, add notes/links/references, mark internal transfers, and enrich transactions with parsed email order data
 - **Email order enrichment** — Configure IMAP email accounts for supported importers like Amazon.de and PayPal.de to scan inbox messages and auto-link parsed orders to ledger transactions; accounts are also scanned automatically in the background (`LEDGER_EMAIL_SCAN_INTERVAL`, default every 6h), and `.eml` upload remains available as a fallback
 - **Category organization** — Per-module categories (e.g. insurance/telecom for contracts, PC hardware/tools for purchases)

--- a/backend/internal/modules/auto/calc.go
+++ b/backend/internal/modules/auto/calc.go
@@ -7,15 +7,14 @@ import (
 )
 
 type YearCosts struct {
-	Year       int     `json:"year"`
-	Service    float64 `json:"service"`
-	Fuel       float64 `json:"fuel"`
-	Insurance  float64 `json:"insurance"`
-	Tax        float64 `json:"tax"`
-	Inspection float64 `json:"inspection"`
-	Tires      float64 `json:"tires"`
-	Misc       float64 `json:"misc"`
-	Total      float64 `json:"total"`
+	Year      int     `json:"year"`
+	Service   float64 `json:"service"`
+	Fuel      float64 `json:"fuel"`
+	Insurance float64 `json:"insurance"`
+	Tax       float64 `json:"tax"`
+	Tires     float64 `json:"tires"`
+	Misc      float64 `json:"misc"`
+	Total     float64 `json:"total"`
 }
 
 type MileagePoint struct {
@@ -129,7 +128,7 @@ func CalculateVehicleSummary(vehicle Vehicle, entries []CostEntry, now time.Time
 		if !ok {
 			yc = &YearCosts{Year: y}
 		}
-		yc.Total = yc.Service + yc.Fuel + yc.Insurance + yc.Tax + yc.Inspection + yc.Tires + yc.Misc
+		yc.Total = yc.Service + yc.Fuel + yc.Insurance + yc.Tax + yc.Tires + yc.Misc
 		summary.CostsByYear = append(summary.CostsByYear, *yc)
 	}
 
@@ -179,8 +178,6 @@ func addToYearCosts(yc *YearCosts, costType string, amount float64) {
 		yc.Insurance += amount
 	case CostTypeTax:
 		yc.Tax += amount
-	case CostTypeInspection:
-		yc.Inspection += amount
 	case CostTypeTires:
 		yc.Tires += amount
 	case CostTypeMisc:
@@ -406,7 +403,7 @@ func calcProjection(vehicle Vehicle, summary VehicleSummary, monthsOwned, kmDriv
 	}
 
 	// Split running cost into service-related and non-service
-	serviceCost := summary.CostsByType[CostTypeService] + summary.CostsByType[CostTypeInspection] + summary.CostsByType[CostTypeTires]
+	serviceCost := summary.CostsByType[CostTypeService] + summary.CostsByType[CostTypeTires]
 	nonServiceCost := totalRunningCost - serviceCost
 
 	// Linear projection with maintenance factor on service costs

--- a/backend/internal/modules/auto/model.go
+++ b/backend/internal/modules/auto/model.go
@@ -60,25 +60,23 @@ func (v *VehicleInput) Validate() error {
 
 // CostEntryType enumerates the predefined cost types.
 const (
-	CostTypeService    = "service"
-	CostTypeFuel       = "fuel"
-	CostTypeInsurance  = "insurance"
-	CostTypeTax        = "tax"
-	CostTypeInspection = "inspection"
-	CostTypeTires      = "tires"
-	CostTypeMileage    = "mileage"
-	CostTypeMisc       = "misc"
+	CostTypeService   = "service"
+	CostTypeFuel      = "fuel"
+	CostTypeInsurance = "insurance"
+	CostTypeTax       = "tax"
+	CostTypeTires     = "tires"
+	CostTypeMileage   = "mileage"
+	CostTypeMisc      = "misc"
 )
 
 var validCostTypes = map[string]bool{
-	CostTypeService:    true,
-	CostTypeFuel:       true,
-	CostTypeInsurance:  true,
-	CostTypeTax:        true,
-	CostTypeInspection: true,
-	CostTypeTires:      true,
-	CostTypeMileage:    true,
-	CostTypeMisc:       true,
+	CostTypeService:   true,
+	CostTypeFuel:      true,
+	CostTypeInsurance: true,
+	CostTypeTax:       true,
+	CostTypeTires:     true,
+	CostTypeMileage:   true,
+	CostTypeMisc:      true,
 }
 
 type CostEntry struct {

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -28,6 +28,8 @@ React 19 + TypeScript SPA built with Vite. No SSR — this is a CRUD/business ap
 
 **Styling:** Tailwind CSS v4 with the Vite plugin. shadcn/ui for pre-built components (config in `components.json`, components go in `src/components/ui/`). Use the `cn()` helper from `@/lib/utils` for conditional classNames.
 
+**Charts:** Recharts, currently used by the auto module's vehicle statistics page (`/auto/vehicles/$vehicleId/statistics`, lazy-loaded). Cost-type series colors are CSS custom properties (`--viz-*`) defined for light and dark mode in `src/index.css` and mapped in `src/modules/auto/config/chart.ts`.
+
 **Path alias:** `@/` maps to `src/` (configured in both tsconfig and vite.config).
 
 **i18n:** `react-i18next` with locale files in `src/i18n/locales/` (en.json, de.json).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,7 @@ React SPA for the Kontor application — a multi-module personal finance manager
 - **TanStack Router** for type-safe routing
 - **TanStack Query** for server state / data fetching
 - **React Hook Form** + **Zod** for forms and validation
+- **Recharts** for charts (vehicle statistics)
 - **react-i18next** for internationalization (en/de)
 
 ## Getting Started

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -28,6 +28,7 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.1",
         "react-i18next": "^16.5.4",
+        "recharts": "^3.9.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
@@ -309,6 +310,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA=="],
@@ -360,6 +363,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -415,6 +420,24 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -424,6 +447,8 @@
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.54.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/type-utils": "8.54.0", "@typescript-eslint/utils": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.54.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ=="],
 
@@ -491,9 +516,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -504,6 +553,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.282", "", {}, "sha512-FCPkJtpst28UmFzd903iU7PdeVTfY0KAeJy+Lk0GLZRwgwYHn/irRcaCbQQOmr5Vytc/7rcavsYLvTM8RiHYhQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -530,6 +581,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -573,9 +626,13 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@11.1.11", "", {}, "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -683,6 +740,10 @@
 
     "react-i18next": ["react-i18next@16.5.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 25.6.2", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g=="],
 
+    "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -690,6 +751,14 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "recharts": ["recharts@3.9.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -750,6 +819,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.1",
     "react-i18next": "^16.5.4",
+    "recharts": "^3.9.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -161,11 +161,10 @@
     "comments": "Kommentare"
   },
   "costTypes": {
-    "service": "Wartung",
+    "service": "Wartung & TÜV/HU",
     "fuel": "Kraftstoff",
     "insurance": "Versicherung",
     "tax": "Steuer",
-    "inspection": "TÜV/HU",
     "tires": "Reifen",
     "mileage": "Kilometerstand",
     "misc": "Sonstiges"
@@ -192,7 +191,11 @@
     "projectedCostPerMonth": "Hochgerechnete Kosten / Monat",
     "projectedCostPerKm": "Hochgerechnete Kosten / km",
     "theoreticalResidual": "Theoretischer Restwert",
-    "requiredSalePrice": "Erforderlicher Verkaufspreis"
+    "requiredSalePrice": "Erforderlicher Verkaufspreis",
+    "statistics": "Statistiken",
+    "costPerKmByYear": "Kosten pro km nach Jahr",
+    "kmPerYear": "Kilometer pro Jahr",
+    "mileageHistory": "Kilometerstand-Verlauf"
   },
   "categoryNames": {
     "insurance": "Versicherung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -161,11 +161,10 @@
     "comments": "Comments"
   },
   "costTypes": {
-    "service": "Service",
+    "service": "Service & Inspection",
     "fuel": "Fuel",
     "insurance": "Insurance",
     "tax": "Tax",
-    "inspection": "Inspection",
     "tires": "Tires",
     "mileage": "Mileage",
     "misc": "Miscellaneous"
@@ -192,7 +191,11 @@
     "projectedCostPerMonth": "Projected Cost / Month",
     "projectedCostPerKm": "Projected Cost / km",
     "theoreticalResidual": "Theoretical Residual Value",
-    "requiredSalePrice": "Required Sale Price"
+    "requiredSalePrice": "Required Sale Price",
+    "statistics": "Statistics",
+    "costPerKmByYear": "Cost per km by year",
+    "kmPerYear": "Kilometers per year",
+    "mileageHistory": "Odometer history"
   },
   "categoryNames": {
     "insurance": "Insurance",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -113,6 +113,25 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* Cost-type series colors for auto module charts (CVD-validated categorical palette) */
+:root {
+  --viz-service: #2a78d6;
+  --viz-fuel: #1baf7a;
+  --viz-insurance: #eda100;
+  --viz-tax: #008300;
+  --viz-tires: #4a3aa7;
+  --viz-misc: #e34948;
+}
+
+.dark {
+  --viz-service: #3987e5;
+  --viz-fuel: #199e70;
+  --viz-insurance: #c98500;
+  --viz-tax: #008300;
+  --viz-tires: #9085e9;
+  --viz-misc: #e66767;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/src/modules/auto/components/cost-entry-dialog.tsx
+++ b/frontend/src/modules/auto/components/cost-entry-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { costEntryFormSchema, type CostEntryFormData, type CostEntry, type CostType } from "@/modules/auto/types"
 import {
@@ -41,7 +41,6 @@ const costTypes: CostType[] = [
   "fuel",
   "insurance",
   "tax",
-  "inspection",
   "tires",
   "mileage",
   "misc",
@@ -55,7 +54,7 @@ const defaultValues: CostEntryFormData = {
 export function CostEntryDialog({ open, onOpenChange, costEntry, onSubmit }: CostEntryDialogProps) {
   const { t } = useTranslation()
   const form = useForm<CostEntryFormData>({
-    resolver: standardSchemaResolver(costEntryFormSchema),
+    resolver: standardSchemaResolver(costEntryFormSchema) as Resolver<CostEntryFormData>,
     defaultValues,
   })
 

--- a/frontend/src/modules/auto/components/vehicle-charts.tsx
+++ b/frontend/src/modules/auto/components/vehicle-charts.tsx
@@ -1,0 +1,336 @@
+import { useTranslation } from "react-i18next"
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import type { VehicleSummary } from "@/modules/auto/types"
+import { chartCostTypes, costTypeColor, type ChartCostType } from "@/modules/auto/config/chart"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+const AXIS_TICK = { fill: "var(--muted-foreground)", fontSize: 12 }
+const AXIS_LINE = { stroke: "var(--border)" }
+
+interface TooltipRow {
+  name: string
+  value: string
+  color?: string
+}
+
+function ChartTooltipBox({ title, rows }: { title: string; rows: TooltipRow[] }) {
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md">
+      <div className="mb-1 font-medium">{title}</div>
+      {rows.map((row) => (
+        <div key={row.name} className="flex items-center gap-2">
+          {row.color && <span className="h-2 w-2 rounded-[2px]" style={{ background: row.color }} />}
+          <span className="text-muted-foreground">{row.name}</span>
+          <span className="ml-auto pl-3 font-medium tabular-nums">{row.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ChartLegend({ items }: { items: { label: string; color: string }[] }) {
+  return (
+    <div className="mt-2 flex flex-wrap justify-center gap-x-4 gap-y-1">
+      {items.map((item) => (
+        <div key={item.label} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="h-2.5 w-2.5 rounded-[3px]" style={{ background: item.color }} />
+          {item.label}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface StackSegmentProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  fill?: string
+  dataKey?: string
+  payload?: { year: number }
+  topKeyByYear: Record<number, string>
+}
+
+// Stacked segments get a 2px surface gap below the segment above them; only the
+// topmost non-zero segment carries the 4px rounded data-end.
+function StackSegment(props: StackSegmentProps) {
+  const { x = 0, y = 0, width = 0, height = 0, fill, dataKey, payload, topKeyByYear } = props
+  if (height <= 0 || width <= 0) return null
+  const isTop = payload && topKeyByYear[payload.year] === dataKey
+  if (!isTop) {
+    const h = Math.max(height - 2, 0)
+    return <rect x={x} y={y + 2} width={width} height={h} fill={fill} />
+  }
+  const r = Math.min(4, height, width / 2)
+  const d = `M ${x},${y + height}
+    L ${x},${y + r}
+    Q ${x},${y} ${x + r},${y}
+    L ${x + width - r},${y}
+    Q ${x + width},${y} ${x + width},${y + r}
+    L ${x + width},${y + height} Z`
+  return <path d={d} fill={fill} />
+}
+
+export function CostsByYearChart({ summary }: { summary: VehicleSummary }) {
+  const { t } = useTranslation()
+  const currency = t("common.currency")
+  const data = summary.costsByYear
+  if (data.length === 0) return null
+
+  const topKeyByYear: Record<number, string> = {}
+  for (const yc of data) {
+    for (const type of chartCostTypes) {
+      if (yc[type] > 0) topKeyByYear[yc.year] = type
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("vehicleSummary.costsByYear")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={data} margin={{ top: 4, right: 8, left: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" />
+            <XAxis dataKey="year" tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={false} />
+            <YAxis tick={AXIS_TICK} axisLine={false} tickLine={false} width={56}
+              tickFormatter={(v: number) => v.toLocaleString()} />
+            <Tooltip
+              cursor={{ fill: "var(--muted)", opacity: 0.4 }}
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null
+                const rows = payload
+                  .filter((p) => typeof p.value === "number" && p.value > 0)
+                  .reverse()
+                  .map((p) => ({
+                    name: t(`costTypes.${p.dataKey}`),
+                    value: `${(p.value as number).toFixed(2)} ${currency}`,
+                    color: costTypeColor(p.dataKey as ChartCostType),
+                  }))
+                const total = payload.reduce((sum, p) => sum + ((p.value as number) || 0), 0)
+                rows.push({ name: t("vehicleSummary.total"), value: `${total.toFixed(2)} ${currency}`, color: "" })
+                return <ChartTooltipBox title={String(label)} rows={rows} />
+              }}
+            />
+            <Legend content={() => (
+              <ChartLegend items={chartCostTypes.map((type) => ({
+                label: t(`costTypes.${type}`),
+                color: costTypeColor(type),
+              }))} />
+            )} />
+            {chartCostTypes.map((type) => (
+              <Bar
+                key={type}
+                dataKey={type}
+                stackId="costs"
+                fill={costTypeColor(type)}
+                maxBarSize={24}
+                isAnimationActive={false}
+                shape={(props: unknown) => (
+                  <StackSegment {...(props as StackSegmentProps)} topKeyByYear={topKeyByYear} />
+                )}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function CostPerKmChart({ summary }: { summary: VehicleSummary }) {
+  const { t } = useTranslation()
+  const currency = t("common.currency")
+  const kmByYear = new Map(summary.mileageByYear.map((ym) => [ym.year, ym]))
+  const data = summary.costsByYear
+    .map((yc) => {
+      const ym = kmByYear.get(yc.year)
+      return {
+        year: yc.year,
+        total: ym && ym.km > 0 ? yc.total / ym.km : null,
+        fuel: ym && ym.fuelCostPerKm > 0 ? ym.fuelCostPerKm : null,
+      }
+    })
+    .filter((row) => row.total != null || row.fuel != null)
+  if (data.length === 0) return null
+
+  const series = [
+    { key: "total", label: t("vehicleSummary.total"), color: "var(--foreground)" },
+    { key: "fuel", label: t("costTypes.fuel"), color: costTypeColor("fuel") },
+  ]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("vehicleSummary.costPerKmByYear")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart data={data} margin={{ top: 4, right: 8, left: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" />
+            <XAxis dataKey="year" tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={false} />
+            <YAxis tick={AXIS_TICK} axisLine={false} tickLine={false} width={48}
+              tickFormatter={(v: number) => v.toFixed(2)} />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null
+                const rows = payload
+                  .filter((p) => typeof p.value === "number")
+                  .map((p) => {
+                    const s = series.find((sr) => sr.key === p.dataKey)
+                    return {
+                      name: s?.label ?? String(p.dataKey),
+                      value: `${(p.value as number).toFixed(2)} ${currency}/km`,
+                      color: s?.color,
+                    }
+                  })
+                return <ChartTooltipBox title={String(label)} rows={rows} />
+              }}
+            />
+            <Legend content={() => <ChartLegend items={series} />} />
+            {series.map((s) => (
+              <Line
+                key={s.key}
+                dataKey={s.key}
+                stroke={s.color}
+                strokeWidth={2}
+                strokeLinecap="round"
+                connectNulls
+                dot={{ r: 4, fill: s.color, stroke: "var(--card)", strokeWidth: 2 }}
+                activeDot={{ r: 5 }}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function KmPerYearChart({ summary }: { summary: VehicleSummary }) {
+  const { t } = useTranslation()
+  const data = summary.mileageByYear
+  if (data.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("vehicleSummary.kmPerYear")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart data={data} margin={{ top: 4, right: 8, left: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" />
+            <XAxis dataKey="year" tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={false} />
+            <YAxis tick={AXIS_TICK} axisLine={false} tickLine={false} width={56}
+              tickFormatter={(v: number) => v.toLocaleString()} />
+            <Tooltip
+              cursor={{ fill: "var(--muted)", opacity: 0.4 }}
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null
+                const km = payload[0].value as number
+                return (
+                  <ChartTooltipBox
+                    title={String(label)}
+                    rows={[{ name: t("vehicleSummary.km"), value: `${Math.round(km).toLocaleString()} km` }]}
+                  />
+                )
+              }}
+            />
+            <Bar
+              dataKey="km"
+              fill="var(--viz-service)"
+              maxBarSize={24}
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function MileageHistoryChart({ summary }: { summary: VehicleSummary }) {
+  const { t } = useTranslation()
+  const data = summary.mileageHistory
+    .map((p) => ({ ts: new Date(p.date).getTime(), mileage: p.mileage }))
+    .filter((p) => !Number.isNaN(p.ts))
+    .sort((a, b) => a.ts - b.ts)
+  if (data.length < 2) return null
+
+  const fmtDate = (ts: number) => new Date(ts).toLocaleDateString()
+
+  const firstYear = new Date(data[0].ts).getFullYear() + 1
+  const lastYear = new Date(data[data.length - 1].ts).getFullYear()
+  const yearTicks: number[] = []
+  for (let y = firstYear; y <= lastYear; y++) {
+    yearTicks.push(Date.UTC(y, 0, 1))
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("vehicleSummary.mileageHistory")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart data={data} margin={{ top: 4, right: 8, left: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" />
+            <XAxis
+              dataKey="ts"
+              type="number"
+              scale="time"
+              domain={["dataMin", "dataMax"]}
+              ticks={yearTicks}
+              tick={AXIS_TICK}
+              axisLine={AXIS_LINE}
+              tickLine={false}
+              tickFormatter={(ts: number) => String(new Date(ts).getFullYear())}
+            />
+            <YAxis tick={AXIS_TICK} axisLine={false} tickLine={false} width={64}
+              tickFormatter={(v: number) => v.toLocaleString()} />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null
+                const point = payload[0].payload as { ts: number; mileage: number }
+                return (
+                  <ChartTooltipBox
+                    title={fmtDate(point.ts)}
+                    rows={[{
+                      name: t("vehicleSummary.currentMileage"),
+                      value: `${Math.round(point.mileage).toLocaleString()} km`,
+                    }]}
+                  />
+                )
+              }}
+            />
+            <Line
+              dataKey="mileage"
+              stroke="var(--viz-service)"
+              strokeWidth={2}
+              strokeLinecap="round"
+              dot={{ r: 4, fill: "var(--viz-service)", stroke: "var(--card)", strokeWidth: 2 }}
+              activeDot={{ r: 5 }}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/modules/auto/components/vehicle-dashboard.tsx
+++ b/frontend/src/modules/auto/components/vehicle-dashboard.tsx
@@ -1,14 +1,6 @@
 import { useTranslation } from "react-i18next"
 import type { VehicleSummary } from "@/modules/auto/types"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 
 interface VehicleDashboardProps {
   summary: VehicleSummary
@@ -20,231 +12,48 @@ export function VehicleDashboard({ summary }: VehicleDashboardProps) {
   const fmt = (n: number) => n.toFixed(2)
   const fmtInt = (n: number) => Math.round(n).toLocaleString()
 
-  const costTypeKeys = ["service", "fuel", "insurance", "tax", "inspection", "tires", "misc"] as const
-
   return (
-    <div className="space-y-6">
-      {/* Overview cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.totalCost")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{fmt(summary.totalCost)} {currency}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.costPerMonth")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{fmt(summary.costPerMonth)} {currency}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.costPerKm")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{summary.costPerKm > 0 ? `${fmt(summary.costPerKm)} ${currency}` : "-"}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.currentMileage")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{summary.currentMileage > 0 ? `${fmtInt(summary.currentMileage)} km` : "-"}</div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Secondary stats */}
-      <div className="grid gap-4 sm:grid-cols-3">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.monthsOwned")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-lg font-semibold">{summary.monthsOwned.toFixed(1)}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.kmPerMonth")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-lg font-semibold">{summary.kmPerMonth > 0 ? `${fmtInt(summary.kmPerMonth)} km` : "-"}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("vehicleSummary.entryCount")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-lg font-semibold">{summary.entryCount}</div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Costs by type */}
-      {Object.keys(summary.costsByType).length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("vehicleSummary.costsByType")}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-              {costTypeKeys.map((type) => {
-                const val = summary.costsByType[type]
-                if (!val) return null
-                return (
-                  <div key={type} className="flex justify-between rounded-md border p-3">
-                    <span className="text-sm text-muted-foreground">{t(`costTypes.${type}`)}</span>
-                    <span className="text-sm font-medium">{fmt(val)} {currency}</span>
-                  </div>
-                )
-              })}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Costs by year */}
-      {summary.costsByYear.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("vehicleSummary.costsByYear")}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t("vehicleSummary.year")}</TableHead>
-                    {costTypeKeys.map((type) => (
-                      <TableHead key={type} className="text-right">{t(`costTypes.${type}`)}</TableHead>
-                    ))}
-                    <TableHead className="text-right font-bold">{t("vehicleSummary.total")}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {summary.costsByYear.map((yc) => (
-                    <TableRow key={yc.year}>
-                      <TableCell className="font-medium">{yc.year}</TableCell>
-                      <TableCell className="text-right">{yc.service > 0 ? fmt(yc.service) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.fuel > 0 ? fmt(yc.fuel) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.insurance > 0 ? fmt(yc.insurance) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.tax > 0 ? fmt(yc.tax) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.inspection > 0 ? fmt(yc.inspection) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.tires > 0 ? fmt(yc.tires) : "-"}</TableCell>
-                      <TableCell className="text-right">{yc.misc > 0 ? fmt(yc.misc) : "-"}</TableCell>
-                      <TableCell className="text-right font-bold">{fmt(yc.total)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Mileage by year */}
-      {summary.mileageByYear && summary.mileageByYear.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("vehicleSummary.mileageByYear")}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t("vehicleSummary.year")}</TableHead>
-                    <TableHead className="text-right">{t("vehicleSummary.km")}</TableHead>
-                    <TableHead className="text-right">{t("vehicleSummary.fuelCostPerKm")}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {summary.mileageByYear.map((ym) => (
-                    <TableRow key={ym.year}>
-                      <TableCell className="font-medium">{ym.year}</TableCell>
-                      <TableCell className="text-right">{fmtInt(ym.km)} km</TableCell>
-                      <TableCell className="text-right">{ym.fuelCostPerKm > 0 ? `${fmt(ym.fuelCostPerKm)} ${currency}` : "-"}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Projection */}
-      {summary.projection && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("vehicleSummary.projection")}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {summary.projection.targetMonths != null && (
-                <div>
-                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.targetMonths")}</div>
-                  <div className="text-sm font-medium">{summary.projection.targetMonths}</div>
-                </div>
-              )}
-              {summary.projection.targetMileage != null && (
-                <div>
-                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.targetMileage")}</div>
-                  <div className="text-sm font-medium">{fmtInt(summary.projection.targetMileage)} km</div>
-                </div>
-              )}
-              <div>
-                <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedTotalCost")}</div>
-                <div className="text-sm font-medium">{fmt(summary.projection.projectedTotalCost)} {currency}</div>
-              </div>
-              <div>
-                <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedCostPerMonth")}</div>
-                <div className="text-sm font-medium">{fmt(summary.projection.projectedCostPerMonth)} {currency}</div>
-              </div>
-              {summary.projection.projectedCostPerKm > 0 && (
-                <div>
-                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedCostPerKm")}</div>
-                  <div className="text-sm font-medium">{fmt(summary.projection.projectedCostPerKm)} {currency}</div>
-                </div>
-              )}
-              {summary.projection.theoreticalResidualValue > 0 && (
-                <div>
-                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.theoreticalResidual")}</div>
-                  <div className="text-sm font-medium">{fmt(summary.projection.theoreticalResidualValue)} {currency}</div>
-                </div>
-              )}
-              {summary.projection.requiredSalePrice > 0 && (
-                <div>
-                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.requiredSalePrice")}</div>
-                  <div className="text-sm font-medium">{fmt(summary.projection.requiredSalePrice)} {currency}</div>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {t("vehicleSummary.totalCost")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{fmt(summary.totalCost)} {currency}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {t("vehicleSummary.costPerMonth")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{fmt(summary.costPerMonth)} {currency}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {t("vehicleSummary.costPerKm")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.costPerKm > 0 ? `${fmt(summary.costPerKm)} ${currency}` : "-"}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {t("vehicleSummary.currentMileage")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.currentMileage > 0 ? `${fmtInt(summary.currentMileage)} km` : "-"}</div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/modules/auto/components/vehicle-dialog.tsx
+++ b/frontend/src/modules/auto/components/vehicle-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { vehicleFormSchema, type VehicleFormData, type Vehicle } from "@/modules/auto/types"
 import { vehicleFields } from "@/modules/auto/config/vehicle-fields"
@@ -30,7 +30,7 @@ const defaultValues: VehicleFormData = {
 export function VehicleDialog({ open, onOpenChange, vehicle, onSubmit }: VehicleDialogProps) {
   const { t } = useTranslation()
   const form = useForm<VehicleFormData>({
-    resolver: standardSchemaResolver(vehicleFormSchema),
+    resolver: standardSchemaResolver(vehicleFormSchema) as Resolver<VehicleFormData>,
     defaultValues,
   })
 

--- a/frontend/src/modules/auto/components/vehicle-statistics.tsx
+++ b/frontend/src/modules/auto/components/vehicle-statistics.tsx
@@ -1,0 +1,219 @@
+import { useTranslation } from "react-i18next"
+import type { VehicleSummary } from "@/modules/auto/types"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { chartCostTypes, costTypeColor } from "@/modules/auto/config/chart"
+import {
+  CostsByYearChart,
+  CostPerKmChart,
+  KmPerYearChart,
+  MileageHistoryChart,
+} from "@/modules/auto/components/vehicle-charts"
+
+interface VehicleStatisticsProps {
+  summary: VehicleSummary
+}
+
+export function VehicleStatistics({ summary }: VehicleStatisticsProps) {
+  const { t } = useTranslation()
+  const currency = t("common.currency")
+  const fmt = (n: number) => n.toFixed(2)
+  const fmtInt = (n: number) => Math.round(n).toLocaleString()
+
+  return (
+    <div className="space-y-6">
+      {/* Secondary stats */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {t("vehicleSummary.monthsOwned")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">{summary.monthsOwned.toFixed(1)}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {t("vehicleSummary.kmPerMonth")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">{summary.kmPerMonth > 0 ? `${fmtInt(summary.kmPerMonth)} km` : "-"}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {t("vehicleSummary.entryCount")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-lg font-semibold">{summary.entryCount}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts */}
+      <CostsByYearChart summary={summary} />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CostPerKmChart summary={summary} />
+        <KmPerYearChart summary={summary} />
+      </div>
+      <MileageHistoryChart summary={summary} />
+
+      {/* Costs by type */}
+      {Object.keys(summary.costsByType).length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("vehicleSummary.costsByType")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {chartCostTypes.map((type) => {
+                const val = summary.costsByType[type]
+                if (!val) return null
+                return (
+                  <div key={type} className="flex items-center gap-2 rounded-md border p-3">
+                    <span className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ background: costTypeColor(type) }} />
+                    <span className="truncate text-sm text-muted-foreground">{t(`costTypes.${type}`)}</span>
+                    <span className="ml-auto whitespace-nowrap text-sm font-medium">{fmt(val)} {currency}</span>
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Costs by year */}
+      {summary.costsByYear.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("vehicleSummary.costsByYear")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("vehicleSummary.year")}</TableHead>
+                    {chartCostTypes.map((type) => (
+                      <TableHead key={type} className="text-right">{t(`costTypes.${type}`)}</TableHead>
+                    ))}
+                    <TableHead className="text-right font-bold">{t("vehicleSummary.total")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {summary.costsByYear.map((yc) => (
+                    <TableRow key={yc.year}>
+                      <TableCell className="font-medium">{yc.year}</TableCell>
+                      <TableCell className="text-right">{yc.service > 0 ? fmt(yc.service) : "-"}</TableCell>
+                      <TableCell className="text-right">{yc.fuel > 0 ? fmt(yc.fuel) : "-"}</TableCell>
+                      <TableCell className="text-right">{yc.insurance > 0 ? fmt(yc.insurance) : "-"}</TableCell>
+                      <TableCell className="text-right">{yc.tax > 0 ? fmt(yc.tax) : "-"}</TableCell>
+                      <TableCell className="text-right">{yc.tires > 0 ? fmt(yc.tires) : "-"}</TableCell>
+                      <TableCell className="text-right">{yc.misc > 0 ? fmt(yc.misc) : "-"}</TableCell>
+                      <TableCell className="text-right font-bold">{fmt(yc.total)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Mileage by year */}
+      {summary.mileageByYear && summary.mileageByYear.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("vehicleSummary.mileageByYear")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("vehicleSummary.year")}</TableHead>
+                    <TableHead className="text-right">{t("vehicleSummary.km")}</TableHead>
+                    <TableHead className="text-right">{t("vehicleSummary.fuelCostPerKm")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {summary.mileageByYear.map((ym) => (
+                    <TableRow key={ym.year}>
+                      <TableCell className="font-medium">{ym.year}</TableCell>
+                      <TableCell className="text-right">{fmtInt(ym.km)} km</TableCell>
+                      <TableCell className="text-right">{ym.fuelCostPerKm > 0 ? `${fmt(ym.fuelCostPerKm)} ${currency}` : "-"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Projection */}
+      {summary.projection && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("vehicleSummary.projection")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {summary.projection.targetMonths != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.targetMonths")}</div>
+                  <div className="text-sm font-medium">{summary.projection.targetMonths}</div>
+                </div>
+              )}
+              {summary.projection.targetMileage != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.targetMileage")}</div>
+                  <div className="text-sm font-medium">{fmtInt(summary.projection.targetMileage)} km</div>
+                </div>
+              )}
+              <div>
+                <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedTotalCost")}</div>
+                <div className="text-sm font-medium">{fmt(summary.projection.projectedTotalCost)} {currency}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedCostPerMonth")}</div>
+                <div className="text-sm font-medium">{fmt(summary.projection.projectedCostPerMonth)} {currency}</div>
+              </div>
+              {summary.projection.projectedCostPerKm > 0 && (
+                <div>
+                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.projectedCostPerKm")}</div>
+                  <div className="text-sm font-medium">{fmt(summary.projection.projectedCostPerKm)} {currency}</div>
+                </div>
+              )}
+              {summary.projection.theoreticalResidualValue > 0 && (
+                <div>
+                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.theoreticalResidual")}</div>
+                  <div className="text-sm font-medium">{fmt(summary.projection.theoreticalResidualValue)} {currency}</div>
+                </div>
+              )}
+              {summary.projection.requiredSalePrice > 0 && (
+                <div>
+                  <div className="text-xs text-muted-foreground">{t("vehicleSummary.requiredSalePrice")}</div>
+                  <div className="text-sm font-medium">{fmt(summary.projection.requiredSalePrice)} {currency}</div>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/modules/auto/config/chart.ts
+++ b/frontend/src/modules/auto/config/chart.ts
@@ -1,0 +1,4 @@
+export const chartCostTypes = ["service", "fuel", "insurance", "tax", "tires", "misc"] as const
+export type ChartCostType = (typeof chartCostTypes)[number]
+
+export const costTypeColor = (type: ChartCostType) => `var(--viz-${type})`

--- a/frontend/src/modules/auto/routes/auto.vehicles.$vehicleId.statistics.tsx
+++ b/frontend/src/modules/auto/routes/auto.vehicles.$vehicleId.statistics.tsx
@@ -1,0 +1,44 @@
+import { getRouteApi, Link } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
+import { ArrowLeft } from "lucide-react"
+import { usePageTitle } from "@/hooks/use-page-title"
+import { useVehicle, useVehicleSummary } from "@/modules/auto/hooks/use-vehicles"
+import { Button } from "@/components/ui/button"
+import { VehicleDashboard } from "@/modules/auto/components/vehicle-dashboard"
+import { VehicleStatistics } from "@/modules/auto/components/vehicle-statistics"
+
+const routeApi = getRouteApi("/auto/vehicles/$vehicleId/statistics")
+
+export function AutoVehicleStatisticsPage() {
+  const { t } = useTranslation()
+  const { vehicleId } = routeApi.useParams()
+  const { data: vehicle } = useVehicle(vehicleId)
+  const { data: summary } = useVehicleSummary(vehicleId)
+
+  usePageTitle(
+    vehicle ? `${vehicle.name} – ${t("vehicleSummary.statistics")}` : t("vehicleSummary.statistics"),
+    t("app.title"),
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" asChild>
+          <Link to="/auto/vehicles/$vehicleId" params={{ vehicleId }}>
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-bold">
+          {vehicle?.name ?? "..."} – {t("vehicleSummary.statistics")}
+        </h1>
+      </div>
+
+      {summary && (
+        <>
+          <VehicleDashboard summary={summary} />
+          <VehicleStatistics summary={summary} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/modules/auto/routes/auto.vehicles.$vehicleId.tsx
+++ b/frontend/src/modules/auto/routes/auto.vehicles.$vehicleId.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react"
-import { createRoute } from "@tanstack/react-router"
+import { createRoute, Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { usePageTitle } from "@/hooks/use-page-title"
 import { toast } from "sonner"
-import { Plus } from "lucide-react"
+import { ChartColumn, Plus } from "lucide-react"
 import { rootRoute } from "@/routes/__root"
 import { moduleGuard } from "@/modules/guard"
 import {
@@ -86,6 +86,12 @@ function AutoVehicleDetailPage() {
       <div className="flex items-center gap-4">
         <h1 className="text-2xl font-bold">{vehicle?.name ?? "..."}</h1>
         <div className="ml-auto flex gap-2">
+          <Button variant="outline" asChild>
+            <Link to="/auto/vehicles/$vehicleId/statistics" params={{ vehicleId }}>
+              <ChartColumn className="mr-2 h-4 w-4" />
+              {t("vehicleSummary.statistics")}
+            </Link>
+          </Button>
           <Button variant="outline" onClick={() => setEditingVehicle(true)}>
             {t("vehicle.editVehicle")}
           </Button>

--- a/frontend/src/modules/auto/routes/routes.ts
+++ b/frontend/src/modules/auto/routes/routes.ts
@@ -5,6 +5,9 @@ import { moduleGuard } from "@/modules/guard"
 import { autoVehicleDetailRoute } from "./auto.vehicles.$vehicleId"
 
 const AutoIndexPage = lazy(() => import("./auto.index").then((module) => ({ default: module.AutoIndexPage })))
+const AutoVehicleStatisticsPage = lazy(() =>
+  import("./auto.vehicles.$vehicleId.statistics").then((module) => ({ default: module.AutoVehicleStatisticsPage })),
+)
 
 export const autoIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -13,7 +16,15 @@ export const autoIndexRoute = createRoute({
   component: AutoIndexPage,
 })
 
+export const autoVehicleStatisticsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/auto/vehicles/$vehicleId/statistics",
+  beforeLoad: moduleGuard("auto"),
+  component: AutoVehicleStatisticsPage,
+})
+
 export const autoRoutes: AnyRoute[] = [
   autoIndexRoute,
   autoVehicleDetailRoute,
+  autoVehicleStatisticsRoute,
 ]

--- a/frontend/src/modules/auto/types.ts
+++ b/frontend/src/modules/auto/types.ts
@@ -6,7 +6,6 @@ export const costTypeSchema = z.enum([
   "fuel",
   "insurance",
   "tax",
-  "inspection",
   "tires",
   "mileage",
   "misc",
@@ -90,7 +89,6 @@ export interface YearCosts {
   fuel: number
   insurance: number
   tax: number
-  inspection: number
   tires: number
   misc: number
   total: number

--- a/frontend/src/modules/contracts/components/contract-dialog.tsx
+++ b/frontend/src/modules/contracts/components/contract-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { contractFormSchema, type ContractFormData, type Contract } from "@/modules/contracts/types"
 import { contractFields } from "@/modules/contracts/config/contract-fields"
@@ -34,7 +34,7 @@ const defaultValues: ContractFormData = {
 export function ContractDialog({ open, onOpenChange, contract, onSubmit }: ContractDialogProps) {
   const { t } = useTranslation()
   const form = useForm<ContractFormData>({
-    resolver: standardSchemaResolver(contractFormSchema),
+    resolver: standardSchemaResolver(contractFormSchema) as Resolver<ContractFormData>,
     defaultValues,
   })
 

--- a/frontend/src/modules/ledger/components/ledger-category-dialog.tsx
+++ b/frontend/src/modules/ledger/components/ledger-category-dialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import type { LedgerCategory, LedgerCategoryInput } from "@/modules/ledger/types"
 import { ledgerCategoryInputSchema } from "@/modules/ledger/types"
@@ -80,7 +80,7 @@ function LedgerCategoryDialogForm({
   const { t } = useTranslation()
   const [matchWordsInput, setMatchWordsInput] = useState((category?.matchWords ?? []).join(", "))
   const form = useForm<LedgerCategoryInput>({
-    resolver: standardSchemaResolver(ledgerCategoryInputSchema),
+    resolver: standardSchemaResolver(ledgerCategoryInputSchema) as Resolver<LedgerCategoryInput>,
     defaultValues: {
       name: category?.name ?? "",
       parentId: category?.parentId ?? initialParentId,

--- a/frontend/src/modules/ledger/components/ledger-email-account-dialog.tsx
+++ b/frontend/src/modules/ledger/components/ledger-email-account-dialog.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { useTranslation } from "react-i18next"
 import type { LedgerEmailAccount, LedgerEmailAccountInput } from "@/modules/ledger/types"
@@ -31,7 +31,7 @@ interface LedgerEmailAccountDialogProps {
 export function LedgerEmailAccountDialog({ open, onOpenChange, account, onSubmit }: LedgerEmailAccountDialogProps) {
   const { t } = useTranslation()
   const form = useForm<LedgerEmailAccountInput>({
-    resolver: standardSchemaResolver(ledgerEmailAccountInputSchema),
+    resolver: standardSchemaResolver(ledgerEmailAccountInputSchema) as Resolver<LedgerEmailAccountInput>,
     defaultValues: {
       name: account?.name ?? "",
       imapHost: account?.imapHost ?? "imap.gmail.com",

--- a/frontend/src/modules/ledger/components/ledger-import-panel.tsx
+++ b/frontend/src/modules/ledger/components/ledger-import-panel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { toast } from "sonner"
 import { Upload } from "lucide-react"
 import { useLedgerCommitImport, useLedgerPreviewImport } from "@/modules/ledger/hooks/use-ledger"
@@ -51,7 +51,7 @@ export function LedgerImportPanel({ accounts }: LedgerImportPanelProps) {
   const [mode, setMode] = useState<"existing" | "new">("existing")
 
   const newAccountForm = useForm<LedgerAccountInput>({
-    resolver: standardSchemaResolver(ledgerAccountInputSchema),
+    resolver: standardSchemaResolver(ledgerAccountInputSchema) as Resolver<LedgerAccountInput>,
     defaultValues: defaultLedgerAccountInput(),
   })
 

--- a/frontend/src/modules/purchases/components/purchase-dialog.tsx
+++ b/frontend/src/modules/purchases/components/purchase-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { useForm } from "react-hook-form"
+import { useForm, type Resolver } from "react-hook-form"
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { purchaseFormSchema, type PurchaseFormData, type Purchase } from "@/modules/purchases/types"
 import { purchaseFields } from "@/modules/purchases/config/purchase-fields"
@@ -30,7 +30,7 @@ const defaultValues: PurchaseFormData = {
 export function PurchaseDialog({ open, onOpenChange, purchase, onSubmit }: PurchaseDialogProps) {
   const { t } = useTranslation()
   const form = useForm<PurchaseFormData>({
-    resolver: standardSchemaResolver(purchaseFormSchema),
+    resolver: standardSchemaResolver(purchaseFormSchema) as Resolver<PurchaseFormData>,
     defaultValues,
   })
 


### PR DESCRIPTION
## Summary

- **Merge `inspection` into `service`** — service and HU are usually done together on one invoice, making transactions impossible to tag cleanly. The cost type enum, validation, `YearCosts`, frontend schema, form dropdown, and i18n labels (now "Service & Inspection" / "Wartung & TÜV/HU") all drop `inspection`. No data migration (DB will be cleared).
- **New vehicle statistics page** at `/auto/vehicles/$vehicleId/statistics` (lazy-loaded so Recharts stays out of the main bundle): stacked costs-by-year chart, cost-per-km-by-year line chart (total + fuel), km-per-year bars, odometer history line, plus the costs-by-type grid, yearly tables, and TCO projection that previously crowded the vehicle page.
- **Slimmed vehicle detail page** to the four headline cards, linked transactions, and the cost entries table, with a Statistics button.
- Chart series colors are a CVD-validated categorical palette defined as CSS custom properties (`--viz-*`) with separate light/dark steps in `index.css`.
- **Build fix:** pin resolver output types (`as Resolver<T>`) at the 7 `useForm` sites — a fresh `bun install` of the committed lockfile failed `tsc -b` on react-hook-form/resolvers generics for schemas with input≠output types (`numericString`). No runtime change.

## Test plan

- `task ci` green (backend tests + lint, frontend lint + build)
- Verified end-to-end against a scratch DB: imported real vehicle data, `costsByType`/`costsByYear` no longer contain `inspection`, `POST /vehicles/{id}/costs` rejects `"inspection"` with 400
- Screenshotted vehicle page and statistics page in light and dark mode with Playwright/Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYegrp45D16haPmGpiqxvu