### PR TITLE
chore: add task to clear the local dev database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ After every change, check whether `AGENTS.md` (root, `backend/`, `frontend/`) an
 ## Commands (from repo root)
 
 - `task dev` — Start backend (Air) + frontend (Vite) concurrently
+- `task dev:clean-db` — Delete the local dev database (`backend/data`)
 - `task ci` — Run the local backend + frontend checks that must pass before committing
 - `task ci:backend` — Run backend test + lint checks
 - `task ci:frontend` — Run frontend lint + build checks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,6 +39,12 @@ tasks:
     cmds:
       - bun run dev
 
+  dev:clean-db:
+    desc: Delete the local dev database (backend/data)
+    dir: backend
+    cmds:
+      - task clean-db
+
   build:
     desc: Build Docker image
     cmds:

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,6 +16,7 @@ After every change, check whether `AGENTS.md` (root, `backend/`, `frontend/`) an
 ## Commands
 
 - `task dev` — Start with Air (live reload), sets `CORS_ORIGIN` for frontend dev server
+- `task clean-db` — Delete the local dev database (`./data`)
 - `task build` — Build the binary
 - `task test` — Run tests
 - `task lint` — Run golangci-lint (use a recent binary compatible with the repo Go version)

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -22,6 +22,11 @@ tasks:
     cmds:
       - air
 
+  clean-db:
+    desc: Delete the local dev database
+    cmds:
+      - rm -rf ./data
+
   build:
     desc: Build the binary
     cmds:


### PR DESCRIPTION
## Summary
- Add `task clean-db` in `backend/Taskfile.yml` that deletes the local BadgerDB dev database (`backend/data`)
- Expose it at the repo root as `task dev:clean-db`
- Document the new commands in the root and backend `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbhKgyNVBRtmkQ2jU4ZRCd