### PR TITLE
fix: persist encrypted ledger email account passwords

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ Module routes live in `frontend/src/modules/{id}/routes/` and are registered thr
 
 All development must be done on feature branches. Never commit directly to `main`. Create a descriptive branch (e.g. `feat/add-export`, `fix/renewal-date-calc`) before making changes.
 
+Commit messages and PR descriptions must not contain AI attribution of any kind: no `Co-Authored-By: Claude` (or similar) trailers, no "Generated with Claude Code" lines, and especially no links to AI assistant sessions.
+
 ## Dev workflow
 
 `task dev` from root starts both services. Vite dev server (port 5173) proxies `/api/*`, `/healthz`, `/readyz`, `/metrics` to the Go backend (port 8080). Open http://localhost:5173 in the browser.

--- a/backend/internal/modules/ledger/email_scheduler.go
+++ b/backend/internal/modules/ledger/email_scheduler.go
@@ -111,6 +111,11 @@ func (s *EmailScanScheduler) scanAccount(ctx context.Context, userID string, acc
 	scanCtx, cancel := context.WithTimeout(ctx, accountScanTimeout)
 	defer cancel()
 
+	if account.EncryptedPassword == "" {
+		s.logger.Warn("skipping email account without stored password", "userID", userID, "accountID", account.ID)
+		s.finishScan(ctx, userID, account, "Background scan skipped: no stored password, re-enter the account password")
+		return
+	}
 	password, err := cryptoutil.DecryptString(account.EncryptedPassword, s.encryptionKey)
 	if err != nil {
 		s.logger.Error("decrypting email account password", "userID", userID, "accountID", account.ID, "error", err)

--- a/backend/internal/modules/ledger/handler_email.go
+++ b/backend/internal/modules/ledger/handler_email.go
@@ -149,6 +149,10 @@ func (h *Handler) TestLedgerEmailAccount(w http.ResponseWriter, r *http.Request)
 		h.storeError(w, err)
 		return
 	}
+	if account.EncryptedPassword == "" {
+		httputil.Error(h.logger, w, http.StatusConflict, "no stored email password; edit the account and re-enter the password")
+		return
+	}
 	password, err := cryptoutil.DecryptString(account.EncryptedPassword, h.emailEncryptionKey)
 	if err != nil {
 		httputil.Error(h.logger, w, http.StatusInternalServerError, "could not decrypt stored email password")
@@ -293,6 +297,10 @@ func (h *Handler) ScanLedgerEmailAccount(w http.ResponseWriter, r *http.Request)
 	} else {
 		if len(h.emailEncryptionKey) == 0 {
 			httputil.Error(h.logger, w, http.StatusInternalServerError, "EMAIL_ENCRYPTION_KEY is not configured")
+			return
+		}
+		if account.EncryptedPassword == "" {
+			httputil.Error(h.logger, w, http.StatusConflict, "no stored email password; edit the account and re-enter the password")
 			return
 		}
 		password, err := cryptoutil.DecryptString(account.EncryptedPassword, h.emailEncryptionKey)

--- a/backend/internal/modules/ledger/model_email.go
+++ b/backend/internal/modules/ledger/model_email.go
@@ -32,6 +32,23 @@ type LedgerEmailAccount struct {
 	UpdatedAt             time.Time  `json:"updatedAt"`
 }
 
+// storableLedgerEmailAccount includes EncryptedPassword for persistence
+// (LedgerEmailAccount has json:"-" on it so it never leaves the API).
+type storableLedgerEmailAccount struct {
+	ID                    uuid.UUID  `json:"id"`
+	Name                  string     `json:"name"`
+	IMAPHost              string     `json:"imapHost"`
+	IMAPPort              int        `json:"imapPort"`
+	Username              string     `json:"username"`
+	EncryptedPassword     string     `json:"encryptedPassword"`
+	UseTLS                bool       `json:"useTls"`
+	ScanSince             string     `json:"scanSince"`
+	LastScanAt            *time.Time `json:"lastScanAt,omitempty"`
+	LastScanStatusMessage string     `json:"lastScanStatusMessage,omitempty"`
+	CreatedAt             time.Time  `json:"createdAt"`
+	UpdatedAt             time.Time  `json:"updatedAt"`
+}
+
 type LedgerEmailAccountInput struct {
 	Name      string `json:"name"`
 	IMAPHost  string `json:"imapHost"`

--- a/backend/internal/modules/ledger/store.go
+++ b/backend/internal/modules/ledger/store.go
@@ -176,22 +176,22 @@ func normalizeLedgerTransaction(t LedgerTransaction) LedgerTransaction {
 }
 
 func loadLedgerEmailAccount(txn *badger.Txn, userID string, id uuid.UUID) (LedgerEmailAccount, error) {
-	var account LedgerEmailAccount
+	var stored storableLedgerEmailAccount
 	item, err := txn.Get(ledEmailAccKey(userID, id))
 	if err != nil {
 		if errors.Is(err, badger.ErrKeyNotFound) {
-			return account, storage.ErrNotFound
+			return LedgerEmailAccount{}, storage.ErrNotFound
 		}
-		return account, err
+		return LedgerEmailAccount{}, err
 	}
 	err = item.Value(func(val []byte) error {
-		return json.Unmarshal(val, &account)
+		return json.Unmarshal(val, &stored)
 	})
-	return account, err
+	return LedgerEmailAccount(stored), err
 }
 
 func storeLedgerEmailAccount(txn *badger.Txn, userID string, account LedgerEmailAccount) error {
-	data, err := json.Marshal(account)
+	data, err := json.Marshal(storableLedgerEmailAccount(account))
 	if err != nil {
 		return err
 	}
@@ -1268,11 +1268,11 @@ func (s *Store) ListLedgerEmailAccounts(_ context.Context, userID string) ([]Led
 		defer it.Close()
 		prefix := ledEmailAccPrefix(userID)
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			var item LedgerEmailAccount
-			if err := it.Item().Value(func(val []byte) error { return json.Unmarshal(val, &item) }); err != nil {
+			var stored storableLedgerEmailAccount
+			if err := it.Item().Value(func(val []byte) error { return json.Unmarshal(val, &stored) }); err != nil {
 				return err
 			}
-			items = append(items, item)
+			items = append(items, LedgerEmailAccount(stored))
 		}
 		return nil
 	})

--- a/backend/internal/modules/ledger/store_test.go
+++ b/backend/internal/modules/ledger/store_test.go
@@ -651,3 +651,46 @@ func TestReviewLedgerTransaction_RejectsCategoryAssignmentForLinkedTransfer(t *t
 		t.Fatalf("transferPairTransactionId = %v, want %s", left.TransferPairTransactionID, rightID)
 	}
 }
+
+func TestLedgerEmailAccount_EncryptedPasswordSurvivesPersistence(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	account := LedgerEmailAccount{
+		ID:                uuid.New(),
+		Name:              "Mailbox",
+		IMAPHost:          "imap.example.com",
+		IMAPPort:          993,
+		Username:          "user@example.com",
+		EncryptedPassword: "encrypted-secret",
+		UseTLS:            true,
+		ScanSince:         "2026-01-01",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if err := s.CreateLedgerEmailAccount(ctx, "test-user", account); err != nil {
+		t.Fatalf("CreateLedgerEmailAccount: %v", err)
+	}
+
+	got, err := s.GetLedgerEmailAccount(ctx, "test-user", account.ID)
+	if err != nil {
+		t.Fatalf("GetLedgerEmailAccount: %v", err)
+	}
+	if got.EncryptedPassword != "encrypted-secret" {
+		t.Errorf("EncryptedPassword = %q, want %q — must survive persistence despite json:\"-\" on the API type", got.EncryptedPassword, "encrypted-secret")
+	}
+
+	got.LastScanStatusMessage = "scanned"
+	if err := s.UpdateLedgerEmailAccount(ctx, "test-user", got); err != nil {
+		t.Fatalf("UpdateLedgerEmailAccount: %v", err)
+	}
+
+	list, err := s.ListLedgerEmailAccounts(ctx, "test-user")
+	if err != nil {
+		t.Fatalf("ListLedgerEmailAccounts: %v", err)
+	}
+	if len(list) != 1 || list[0].EncryptedPassword != "encrypted-secret" {
+		t.Errorf("list = %+v, want the encrypted password preserved", list)
+	}
+}


### PR DESCRIPTION
## Summary

- `storeLedgerEmailAccount` marshalled the API type, whose `EncryptedPassword` carries `json:"-"` — the encrypted IMAP password was silently dropped on every save, so stored-credential connection tests and scans could never decrypt anything
- Persistence now goes through a `storableLedgerEmailAccount` struct (same pattern as `core.storableUser`); API responses and exports still never contain the secret
- Accounts saved before this fix have an empty stored password that cannot be recovered: the test/scan endpoints now return a clear 409 "re-enter the password" instead of a generic 500, and the background scheduler skips such accounts with a descriptive status message
- Also documents in `AGENTS.md` that commit messages and PR descriptions must stay free of AI attribution (trailers, "Generated with" lines, session links)

## Test plan

- [x] New regression test `TestLedgerEmailAccount_EncryptedPasswordSurvivesPersistence` (create → get → update → list roundtrip)
- [x] `task ci` passes
- [x] Manual: re-enter the IMAP password on an existing email account, restart the backend, and verify "Test connection" still works